### PR TITLE
Added EIC PID code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@
 ## Instructions
 
 Install Delphes3 following:
-https://github.com/stephensekula/delphes
+https://github.com/stephensekula/delphes (**see below the section on "Setting up the code" for detailed instructions**)
 
-The detector card contains an EIC detector based on the EIC detector handbook v1.2
+The detector card (ending in `.tcl`) contains an EIC detector based on the EIC detector handbook v1.2
 http://www.eicug.org/web/sites/default/files/EIC_HANDBOOK_v1.2.pdf
 
-So far it incorporates tracking, EMCAL and HCAL. PID systems can be implemented using either the EICPIDDetector class or the IdentificationMap class. See delphes/README_EIC.md for information about how to use the PID code from EIC.
+So far it incorporates tracking, EMCAL and HCAL. PID systems can be implemented using either the EICPIDDetector class or the IdentificationMap class. See `delphes/README_EIC.md` in the main DELPHES project linked above for information about how to use the PID code from EIC.
 
-Magnetic field: 1.5 T, Solenoid length: 2.0 m, Tracker radius: 80 cm. 
+* Magnetic field: 1.5 T
+* Solenoid length: 2.0 m
+* Tracker radius: 80 cm
 
-You can run Pythia8 within Delphes. The command file shown here is suitable for DIS at EIC. 
+You can run Pythia8 within Delphes. Again, detailed instructions for patching and installing it are below. The command file (ending in `.cmnd`) shown here is suitable for DIS at EIC. 
 
 Run generation command:
 `./DelphesPythia8 cards/delphes_card_EIC.tcl examples/Pythia8/DIS.cmnd out.root`
@@ -26,8 +28,7 @@ You can see examples of analysis code in the Delphes page above
 Run visualization command:
  `root -l examples/EventDisplay.C'("cards/delphes_card_EIC.tcl","out.root")'`
  
-The two examples shown here are for neutral-current and charged-current event 
-for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass energy). 
+The two examples shown here are for neutral-current and charged-current event for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass energy). 
 
 
 ## Setting up the code

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # delphes_EIC
 
+## New!
+
+* This code now can bridge the EIC PID group's detector response codes into DELPHES. However, for now to do this you need a special fork of DELPHES3 and a special fork of the PID code. We hope in the future this can be harmonized.
+
+## Instructions
+
 Install Delphes3 following:
-https://github.com/delphes/delphes
+https://github.com/stephensekula/delphes
 
 The detector card contains an EIC detector based on the EIC detector handbook v1.2
 http://www.eicug.org/web/sites/default/files/EIC_HANDBOOK_v1.2.pdf
 
-So far it incorporates tracking, EMCAL and HCAL but lacks implementation of PID (it can be done though, following the LHCb card example)
+So far it incorporates tracking, EMCAL and HCAL. PID systems can be implemented using either the EICPIDDetector class or the IdentificationMap class. See delphes/README_EIC.md for information about how to use the PID code from EIC.
 
 Magnetic field: 1.5 T, Solenoid length: 2.0 m, Tracker radius: 80 cm. 
 
@@ -44,14 +50,16 @@ for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass en
    * Install it, ```make install```,
    * Make sure the work area binary directory is in your PATH: ```PATH=/users/ssekula/scratch/EIC/bin:${PATH}```,
 1. Install Delphes,
-   * https://github.com/delphes/delphes,
+   * https://github.com/stephensekula/delphes,
    * Clone the project and make sure you are on the master branch,
+   * Follow the instructions in README_EIC.md to install the EIC PID code as an external library. Do this BEFORE compiling.
    * Make sure ROOT is available in your path, e.g. ```lsetup \"root 6.18.04-x86_64-centos7-gcc8-opt\"```,
    * Compile with PYTHIA8: ```HAS_PYTHIA8=true PYTHIA8=/users/ssekula/scratch/EIC ./configure --prefix=/users/ssekula/scratch/EIC/```,
    * Build: ```make -j```,
    * Install: ```make install```,
 1. Get the Delphes/EIC code for simulation and analysis of a detector baseline/configuration.,
    * https://github.com/miguelignacio/delphes_EIC,
+      * For the EIC PID code examples, you may need the fork https://github.com/stephensekula/delphes_EIC until the code is harmonized with the original project
    * Clone the repository locally,
    * Follow the instructions to run the example and generate a ROOT file.
 
@@ -83,6 +91,8 @@ Beam energy recommended benchmarking points are (the order is hadron on lepton):
 
 SimpleAnalysis is a basic C++ framework that can operate on the ROOT files produced by Delphes. To compile:
 
+This requires a recent version of gcc to be compiled, as it employs features from C++-14. GCC 8.X or higher should suffice. 
+
 ```
 cd SimpleAnalysis/
 export DELPHES_PATH=<PATH TO DELPHES INSTALLATION>
@@ -102,6 +112,6 @@ This runs on a single Delphes ROOT file and produces a new output file, test.roo
 * MuonPIDModule: same as kaon PID, but for muons
 * TaggingModule: Uses the lists of kaon, muon, and electron candidates provided by the above modules, as well as an implementation of signed-high-impact-parameter track finding, to tag jets.
 
-The output file contains one entry per jet studied with a few basic jet variables. These can be processed using the scripts in ```SimpleAnalysis/scripts``` to make some plots.
+The output file contains one entry per proton-proton collision, with a variety of branches to use. These can be processed using the scripts in ```SimpleAnalysis/scripts``` to make some plots.
 
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass en
 1. Install PYTHIA8,
    * http://home.thep.lu.se/~torbjorn/Pythia.html,
    * Download the tarball and unpack it. ,
+   * There is a known BUG in Pythia8.X that affects deep-inelastic scattering (DIS) simulations. To fix this, you need to follow the instructions below on "Patching Pythia8 for DIS". **DO THIS NOW**
    * Configure it for local installation in your work area, e.g. ```./configure --prefix=/users/ssekula/scratch/EIC/ --with-lhapdf6=/scratch/users/ssekula/EIC/```,
    * Build it, ```make -j```,
    * Install it, ```make install```,
@@ -63,6 +64,25 @@ for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass en
    * Clone the repository locally,
    * Follow the instructions to run the example and generate a ROOT file.
 
+## Patching Pythia8 for DIS
+
+* Edit the following file in your Pythia8 source directory: `src/BeamRemnants.cc`
+* Go to the `BeamRemnants::setOneRemnKinematics` method (it will begin around line 960 or so)
+* Find the lines that look as follows:
+
+```
+int iLepScat = isDIS ? (beamOther[0].iPos() + 2) : -1;
+```
+* Add the following lines just below this code:
+```
+if (iLepScat > (event.size()-1)) {
+   // Occasionally, the remnant is missing from the record.
+   // Return false 
+   return false;
+ }
+```
+
+Now compile the Pythia8 code. This will fix the bug.
 
 ## Running Monte Carlo Production
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ for beam energies of 10 GeV electron on 100 GeV proton (63 GeV center-of-mass en
    * Install: ```make install```,
 1. Get the Delphes/EIC code for simulation and analysis of a detector baseline/configuration.,
    * https://github.com/miguelignacio/delphes_EIC,
-      * For the EIC PID code examples, you may need the fork https://github.com/stephensekula/delphes_EIC until the code is harmonized with the original project
    * Clone the repository locally,
    * Follow the instructions to run the example and generate a ROOT file.
 

--- a/SimpleAnalysis/AnalysisFunctions.cc
+++ b/SimpleAnalysis/AnalysisFunctions.cc
@@ -197,7 +197,7 @@ inline float sIP3D(Jet *jet, Track *track)
   if (!IsTaggingTrack(track) || TMath::IsNaN(sip) || !TMath::Finite(sip)) {
     // Tracks far outside the beamspot region should be ignored (Ks, Lambda,
     // etc.); tracks with bad d0, z0 error values, etc. should be ignored.
-    sip = -999.0;
+    sip = -199.0;
   }
 
   return sip;

--- a/SimpleAnalysis/AnalysisFunctions.cc
+++ b/SimpleAnalysis/AnalysisFunctions.cc
@@ -5,6 +5,7 @@
 #include "TLorentzVector.h"
 #include "TVector3.h"
 #include "TClonesArray.h"
+#include "TMath.h"
 
 #include <vector>
 #include <string>
@@ -16,10 +17,12 @@
 
 // Template functions for applying cuts and selecting subsets of particle lists
 
-template <class T> std::vector<T*> SelectorFcn(std::vector<T*> particles, bool selector(T*)) 
+template<class T>std::vector<T *>                                  SelectorFcn(std::vector<T *>particles,
+                                                              bool                             selector(T *))
 {
-  std::vector<T*> output_list;
-  for (T* particle : particles) {
+  std::vector<T *> output_list;
+
+  for (T *particle : particles) {
     if (selector(particle)) {
       output_list.push_back(particle);
     }
@@ -28,99 +31,117 @@ template <class T> std::vector<T*> SelectorFcn(std::vector<T*> particles, bool s
   return output_list;
 }
 
-
 // Computations of fundamental quantities, like Bjorken x, etc.
 
 
-inline std::map<std::string, float> DISVariables(TClonesArray *branchParticle)
+inline std::map<std::string, float>DISVariables(TClonesArray *branchParticle)
 {
   // four-momenta of proton, electron, virtual photon/Z^0/W^+-.
-  auto pProton      = static_cast<GenParticle *>(branchParticle->At(0))->P4(); //these numbers 0 , 3, 5 are hardcoded in Pythia8
-  auto pleptonIn    = static_cast<GenParticle *>(branchParticle->At(3))->P4();
-  auto pleptonOut   = static_cast<GenParticle *>(branchParticle->At(5))->P4();
-  auto pPhoton      = pleptonIn - pleptonOut;
-  
+  auto pProton = static_cast<GenParticle *>(branchParticle->At(0))->P4(); // these
+                                                                          // numbers
+                                                                          // 0
+                                                                          // ,
+                                                                          // 3,
+                                                                          // 5
+                                                                          // are
+                                                                          // hardcoded
+                                                                          // in
+                                                                          // Pythia8
+  auto pleptonIn  = static_cast<GenParticle *>(branchParticle->At(3))->P4();
+  auto pleptonOut = static_cast<GenParticle *>(branchParticle->At(5))->P4();
+  auto pPhoton    = pleptonIn - pleptonOut;
+
   // Q2, W2, Bjorken x, y, nu.
   float Q2 = -pPhoton.M2();
   float W2 = (pProton + pPhoton).M2();
-  float x = Q2 / (2. * pProton.Dot(pPhoton));
-  float y = (pProton.Dot(pPhoton)) / (pProton.Dot(pleptonIn));
+  float x  = Q2 / (2. * pProton.Dot(pPhoton));
+  float y  = (pProton.Dot(pPhoton)) / (pProton.Dot(pleptonIn));
 
-  
+
   std::map<std::string, float> dis_variables;
   dis_variables["Q2"] = Q2;
   dis_variables["W2"] = W2;
-  dis_variables["x"] = x;
-  dis_variables["y"] = y;
-  
+  dis_variables["x"]  = x;
+  dis_variables["y"]  = y;
+
   return dis_variables;
 }
 
-inline std::map<std::string, float> DISJacquetBlondel(TClonesArray* tracks, 
-						      TClonesArray* electrons,
-						      TClonesArray* photons,
-						      TClonesArray* neutral_hadrons)
+inline std::map<std::string, float>DISJacquetBlondel(TClonesArray *tracks,
+                                                     TClonesArray *electrons,
+                                                     TClonesArray *photons,
+                                                     TClonesArray *neutral_hadrons)
 {
   // Jacquet-Blondel method:
   float delta_track = 0.0;
-  auto temp_p = TVector3();
-  for (int i = 0 ; i < tracks->GetEntries(); i++) {
-    auto track_mom = static_cast<Track*>(tracks->At(i))->P4();
+  auto  temp_p      = TVector3();
+
+  for (int i = 0; i < tracks->GetEntries(); i++) {
+    auto track_mom = static_cast<Track *>(tracks->At(i))->P4();
+
     if (isnan(track_mom.E()))
       continue;
     delta_track += (track_mom.E() - track_mom.Pz());
-    temp_p = temp_p + track_mom.Vect();
+    temp_p       = temp_p + track_mom.Vect();
   }
 
   float delta_track_noel = 0.0;
-  if (electrons->GetEntries()>0) {
-    auto e = static_cast<Track*>(electrons->At(0))->P4();
+
+  if (electrons->GetEntries() > 0) {
+    auto e = static_cast<Track *>(electrons->At(0))->P4();
+
     if (!isnan(e.E())) {
       delta_track_noel = delta_track - (e.E() - e.Pz());
     }
   }
-  
+
   float delta_photon = 0.0;
+
   for (int i = 0; i < photons->GetEntries(); i++) {
-    auto pf_mom = static_cast<Photon*>(photons->At(i))->P4();
+    auto pf_mom = static_cast<Photon *>(photons->At(i))->P4();
+
     if (isnan(pf_mom.E()))
       continue;
     delta_photon += (pf_mom.E() - pf_mom.Pz());
-    temp_p = temp_p + pf_mom.Vect();
+    temp_p        = temp_p + pf_mom.Vect();
   }
 
-  float delta_neutral = 0;
+  float delta_neutral          = 0;
   float delta_neutral_noBarrel = 0;
-  auto ptmiss_noBarrel = TVector3();
-    
+  auto  ptmiss_noBarrel        = TVector3();
+
   for (int i = 0; i < neutral_hadrons->GetEntries(); i++) {
-    auto pf_mom = static_cast<Tower*>(neutral_hadrons->At(i))->P4();
+    auto pf_mom = static_cast<Tower *>(neutral_hadrons->At(i))->P4();
+
     if (isnan(pf_mom.E()))
       continue;
     delta_neutral += (pf_mom.E() - pf_mom.Pz());
-    temp_p = temp_p+ pf_mom.Vect();
-    if (TMath::Abs(pf_mom.Eta())>1.0) {
+    temp_p         = temp_p + pf_mom.Vect();
+
+    if (TMath::Abs(pf_mom.Eta()) > 1.0) {
       delta_neutral_noBarrel += (pf_mom.E() - pf_mom.Pz());
-      ptmiss_noBarrel = ptmiss_noBarrel + pf_mom.Vect();
+      ptmiss_noBarrel         = ptmiss_noBarrel + pf_mom.Vect();
     }
   }
 
   float delta = delta_track + delta_photon + delta_neutral;
-  //delta_noel = delta_track_noel + delta_photon + delta_neutral
-  //delta_noel_noBarrel = delta_track_noel + delta_photon + delta_neutral_noBarrel
+
+  // delta_noel = delta_track_noel + delta_photon + delta_neutral
+  // delta_noel_noBarrel = delta_track_noel + delta_photon +
+  // delta_neutral_noBarrel
   float delta_noBarrel = delta_track + delta_photon + delta_neutral_noBarrel;
-    
-  float y_JB   = delta/(2.0*10.0);
-  auto ptmiss = temp_p.Perp();
-  float Q2_JB  = (ptmiss*ptmiss)/(1.0-y_JB);
-  float s     = 4.0*10.0*275.0;
-  float x_JB  = Q2_JB/(s*y_JB);
+
+  float y_JB   = delta / (2.0 * 10.0);
+  auto  ptmiss = temp_p.Perp();
+  float Q2_JB  = (ptmiss * ptmiss) / (1.0 - y_JB);
+  float s      = 4.0 * 10.0 * 275.0;
+  float x_JB   = Q2_JB / (s * y_JB);
 
   std::map<std::string, float> dis_variables;
-  dis_variables["x_JB"] = x_JB;
+  dis_variables["x_JB"]  = x_JB;
   dis_variables["Q2_JB"] = Q2_JB;
-  dis_variables["y_JB"] = y_JB;
-  
+  dis_variables["y_JB"]  = y_JB;
+
   return dis_variables;
 }
 
@@ -128,7 +149,7 @@ inline std::map<std::string, float> DISJacquetBlondel(TClonesArray* tracks,
 // Tagging Methods
 //
 
-inline bool IsTaggingTrack(Track* track)
+inline bool IsTaggingTrack(Track *track)
 {
   bool good_track = true;
 
@@ -143,53 +164,54 @@ inline bool IsTaggingTrack(Track* track)
   // (e.g. with small d0 but large z0)
   // Use a 3D impact parameter maximum to constrain these tracks.
 
-  float r0 = TMath::Sqrt(d0*d0 + z0*z0);
+  float r0 = TMath::Sqrt(d0 * d0 + z0 * z0);
 
   if (r0 > 3.0) // mm
-	  good_track &= false;
+    good_track &= false;
 
   return good_track;
 }
 
-
-inline float sIP3D(Jet* jet, Track* track)
+inline float sIP3D(Jet *jet, Track *track)
 {
-  const TLorentzVector &jetMomentum = jet->P4();
-  float jpx = jetMomentum.Px();
-  float jpy = jetMomentum.Py();
-  float jpz = jetMomentum.Pz();
+  const TLorentzVector& jetMomentum = jet->P4();
+  float jpx                         = jetMomentum.Px();
+  float jpy                         = jetMomentum.Py();
+  float jpz                         = jetMomentum.Pz();
 
   float d0 = TMath::Abs(track->D0);
 
-  float xd = track->Xd;
-  float yd = track->Yd;
-  float zd = track->Zd;
+  float xd  = track->Xd;
+  float yd  = track->Yd;
+  float zd  = track->Zd;
   float dd0 = TMath::Abs(track->ErrorD0);
-  float dz = TMath::Abs(track->DZ);
+  float dz  = TMath::Abs(track->DZ);
   float ddz = TMath::Abs(track->ErrorDZ);
-  
+
   int sign = (jpx * xd + jpy * yd + jpz * zd > 0.0) ? 1 : -1;
-  //add transverse and longitudinal significances in quadrature
+
+  // add transverse and longitudinal significances in quadrature
   float sip = sign * TMath::Sqrt(TMath::Power(d0 / dd0, 2) + TMath::Power(dz / ddz, 2));
-  
+
   // if (d0 > 3) { // 3mm maximum in d0
-  if (!IsTaggingTrack(track)) {
-    // Tracks far outside the beamspot region should be ignored (Ks, Lambda, etc.)
+  if (!IsTaggingTrack(track) || TMath::IsNaN(sip) || !TMath::Finite(sip)) {
+    // Tracks far outside the beamspot region should be ignored (Ks, Lambda,
+    // etc.); tracks with bad d0, z0 error values, etc. should be ignored.
     sip = -999.0;
   }
 
   return sip;
 }
 
-
-inline bool Tagged_Kaon(Jet* jet, std::vector<Track*> kaons, float minSignif, float minPT, int minKaons)
+inline bool Tagged_Kaon(Jet *jet, std::vector<Track *>kaons, float minSignif, float minPT, int minKaons)
 {
-  bool tagged = false;
-  int kaon_count = 0;
+  bool tagged     = false;
+  int  kaon_count = 0;
+
   for (auto kaon : kaons) {
-    if (kaon->P4().DeltaR( jet->P4() ) > 0.5)
+    if (kaon->P4().DeltaR(jet->P4()) > 0.5)
       continue;
-    
+
     if (kaon->PT < minPT)
       continue;
 
@@ -206,19 +228,20 @@ inline bool Tagged_Kaon(Jet* jet, std::vector<Track*> kaons, float minSignif, fl
       break;
   }
 
-  tagged = (kaon_count >= minKaons); 
+  tagged = (kaon_count >= minKaons);
 
   return tagged;
 }
 
-inline bool Tagged_Electron(Jet* jet, std::vector<Track*> electrons, float minSignif, float minPT, int minElectrons)
+inline bool Tagged_Electron(Jet *jet, std::vector<Track *>electrons, float minSignif, float minPT, int minElectrons)
 {
-  bool tagged = false;
-  int electron_count = 0;
+  bool tagged         = false;
+  int  electron_count = 0;
+
   for (auto electron : electrons) {
-    if (electron->P4().DeltaR( jet->P4() ) > 0.5)
+    if (electron->P4().DeltaR(jet->P4()) > 0.5)
       continue;
-    
+
     if (electron->PT < minPT)
       continue;
 
@@ -234,22 +257,23 @@ inline bool Tagged_Electron(Jet* jet, std::vector<Track*> electrons, float minSi
       break;
   }
 
-  tagged = (electron_count >= minElectrons); 
+  tagged = (electron_count >= minElectrons);
 
   return tagged;
 }
 
-inline bool Tagged_Muon(Jet* jet, std::vector<Track*> muons, float minSignif, float minPT, int minMuons)
+inline bool Tagged_Muon(Jet *jet, std::vector<Track *>muons, float minSignif, float minPT, int minMuons)
 {
-  bool tagged = false;
-  int muon_count = 0;
+  bool tagged     = false;
+  int  muon_count = 0;
+
   for (auto muon : muons) {
-    if (muon->P4().DeltaR( jet->P4() ) > 0.5)
+    if (muon->P4().DeltaR(jet->P4()) > 0.5)
       continue;
-    
+
     if (muon->PT < minPT)
       continue;
-    
+
     if (!IsTaggingTrack(muon))
       continue;
 
@@ -263,70 +287,65 @@ inline bool Tagged_Muon(Jet* jet, std::vector<Track*> muons, float minSignif, fl
       break;
   }
 
-  tagged = (muon_count >= minMuons); 
+  tagged = (muon_count >= minMuons);
 
   return tagged;
 }
 
-inline bool Tagged_sIP3D(Jet* jet, TClonesArray tracks,
-		  float minSignif, float minPT, int minTracks)
+inline bool Tagged_sIP3D(Jet *jet, TClonesArray tracks,
+                         float minSignif, float minPT, int minTracks)
 {
   bool tagged = false;
 
-  const TLorentzVector &jetMomentum = jet->P4();
-  float jpx = jetMomentum.Px();
-  float jpy = jetMomentum.Py();
-  float jpz = jetMomentum.Pz();
-  
+  const TLorentzVector& jetMomentum = jet->P4();
+  float jpx                         = jetMomentum.Px();
+  float jpy                         = jetMomentum.Py();
+  float jpz                         = jetMomentum.Pz();
+
   auto jet_constituents = tracks;
 
   int N_sIPtrack = 0;
 
-  // std::cout << "------------ Processing Jet " << jet << " ------------" << std::endl;
+  // std::cout << "------------ Processing Jet " << jet << " ------------" <<
+  // std::endl;
 
   for (int iconst = 0; iconst < jet_constituents.GetEntries(); iconst++) {
-
-
-    if (N_sIPtrack >= minTracks) 
+    if (N_sIPtrack >= minTracks)
       break;
 
     auto constituent = jet_constituents.At(iconst);
-    
-    if(constituent == 0) continue;
+
+    if (constituent == 0) continue;
 
     if (constituent->IsA() == Track::Class()) {
-      auto track = static_cast<Track*>(constituent);
-    
-      const TLorentzVector &trkMomentum = track->P4();
-      float tpt = trkMomentum.Pt();
-      if(tpt < minPT) continue;
+      auto track = static_cast<Track *>(constituent);
+
+      const TLorentzVector& trkMomentum = track->P4();
+      float tpt                         = trkMomentum.Pt();
+
+      if (tpt < minPT) continue;
 
       if (trkMomentum.DeltaR(jetMomentum) > 0.5)
-	continue;
+        continue;
 
       // Avoid decays that are too far from the beamspot (e.g. Ks, etc.)
       // float d0 = TMath::Abs(track->D0);
       // float z0 = TMath::Abs(track->DZ);
-      if (!IsTaggingTrack(track)) 
-	      continue;
+      if (!IsTaggingTrack(track))
+        continue;
 
       float sip = sIP3D(jet, track);
 
 
-      if(sip > minSignif) N_sIPtrack++;
+      if (sip > minSignif) N_sIPtrack++;
     }
-
-      
-
-
   }
-  
+
   tagged = (N_sIPtrack >= minTracks);
+
   // std::cout << "------------ xxxxxxxxxxxxxx ------------" << std::endl;
 
   return tagged;
 }
 
-
-
-#endif
+#endif // ifndef ANALYSISFUNCTIONS

--- a/SimpleAnalysis/EventSelectionModule.cc
+++ b/SimpleAnalysis/EventSelectionModule.cc
@@ -9,24 +9,19 @@
 #include "TreeHandler.h"
 
 #include <iostream>
-#include <iomanip>  
+#include <iomanip>
 #include <fstream>
 #include <algorithm>
 
-EventSelectionModule::EventSelectionModule(ExRootTreeReader* data)
+EventSelectionModule::EventSelectionModule(ExRootTreeReader *data)
   : Module(data)
-{
-
-}
+{}
 
 EventSelectionModule::~EventSelectionModule()
-{
-
-}
+{}
 
 void EventSelectionModule::initialize()
 {
-
   // Get the pointer to the mRICH tracks
   _branch_mRICHTracks = getData()->UseBranch("mRICHTrack");
 
@@ -35,32 +30,31 @@ void EventSelectionModule::initialize()
   TreeHandler *tree_handler = tree_handler->getInstance();
 
   if (tree_handler->getTree() != nullptr) {
-
-    _jet_n = 0;
-    _jet_pt = std::vector<float>();
-    _jet_eta = std::vector<float>();
-    _jet_flavor = std::vector<int>();
+    _jet_n             = 0;
+    _jet_pt            = std::vector<float>();
+    _jet_eta           = std::vector<float>();
+    _jet_flavor        = std::vector<int>();
     _jet_nconstituents = std::vector<int>();
-    _jet_sip3dtag = std::vector<int>();
-  
-    _jet_ktag = std::vector<int>();
-    _jet_k1_pt = std::vector<float>();  
-    _jet_k1_sIP3D = std::vector<float>();  
-    _jet_k2_pt = std::vector<float>();  
-    _jet_k2_sIP3D = std::vector<float>();  
+    _jet_sip3dtag      = std::vector<int>();
 
-    _jet_t1_pt = std::vector<float>();  
-    _jet_t1_sIP3D = std::vector<float>();  
-    _jet_t2_pt = std::vector<float>();  
-    _jet_t2_sIP3D = std::vector<float>();  
-    _jet_t3_pt = std::vector<float>();  
-    _jet_t3_sIP3D = std::vector<float>();  
-    _jet_t4_pt = std::vector<float>();  
-    _jet_t4_sIP3D = std::vector<float>();  
+    _jet_ktag     = std::vector<int>();
+    _jet_k1_pt    = std::vector<float>();
+    _jet_k1_sIP3D = std::vector<float>();
+    _jet_k2_pt    = std::vector<float>();
+    _jet_k2_sIP3D = std::vector<float>();
+
+    _jet_t1_pt    = std::vector<float>();
+    _jet_t1_sIP3D = std::vector<float>();
+    _jet_t2_pt    = std::vector<float>();
+    _jet_t2_sIP3D = std::vector<float>();
+    _jet_t3_pt    = std::vector<float>();
+    _jet_t3_sIP3D = std::vector<float>();
+    _jet_t4_pt    = std::vector<float>();
+    _jet_t4_sIP3D = std::vector<float>();
 
 
-    _jet_etag = std::vector<int>();
-    _jet_mutag = std::vector<int>();
+    _jet_etag   = std::vector<int>();
+    _jet_mutag  = std::vector<int>();
     _jet_charge = std::vector<float>();
 
     tree_handler->getTree()->Branch("jet_n",        &_jet_n, "jet_n/I");
@@ -90,16 +84,16 @@ void EventSelectionModule::initialize()
     tree_handler->getTree()->Branch("jet_mutag",    "std::vector<int>", &_jet_mutag);
     tree_handler->getTree()->Branch("jet_charge",    "std::vector<float>", &_jet_charge);
 
-    _jet_Ks_mass = std::vector<std::vector<float>>();
-    _jet_Ks_p = std::vector<std::vector<float>>();
-    _jet_Ks_flightlength = std::vector<std::vector<float>>();
-    _jet_Ks_sumpt = std::vector<float>();
-    _jet_K_sumpt = std::vector<float>();
-    _jet_Ks_zhadron = std::vector<std::vector<float>>();
-    _jet_K_zhadron = std::vector<std::vector<float>>();
+    _jet_Ks_mass            = std::vector<std::vector<float> >();
+    _jet_Ks_p               = std::vector<std::vector<float> >();
+    _jet_Ks_flightlength    = std::vector<std::vector<float> >();
+    _jet_Ks_sumpt           = std::vector<float>();
+    _jet_K_sumpt            = std::vector<float>();
+    _jet_Ks_zhadron         = std::vector<std::vector<float> >();
+    _jet_K_zhadron          = std::vector<std::vector<float> >();
     _jet_Ks_leading_zhadron = std::vector<float>();
-    _jet_K_leading_zhadron =  std::vector<float>();
-    _jet_ehadoveremratio = std::vector<float>();
+    _jet_K_leading_zhadron  =  std::vector<float>();
+    _jet_ehadoveremratio    = std::vector<float>();
 
     tree_handler->getTree()->Branch("jet_Ks_mass",          "std::vector<std::vector<float>>", &_jet_Ks_mass);
     tree_handler->getTree()->Branch("jet_Ks_p",             "std::vector<std::vector<float>>", &_jet_Ks_p);
@@ -112,8 +106,8 @@ void EventSelectionModule::initialize()
     tree_handler->getTree()->Branch("jet_K_leading_zhadron",             "std::vector<float>", &_jet_K_leading_zhadron);
     tree_handler->getTree()->Branch("jet_ehadoveremratio",  "std::vector<float>", &_jet_ehadoveremratio);
 
-    _charmjet_n = 0;
-    _charmjet_pt = std::vector<float>();
+    _charmjet_n   = 0;
+    _charmjet_pt  = std::vector<float>();
     _charmjet_eta = std::vector<float>();
     tree_handler->getTree()->Branch("charmjet_n", &_charmjet_n, "charmjet_n/I");
     tree_handler->getTree()->Branch("charmjet_pt", "std::vector<float>", &_charmjet_pt);
@@ -122,64 +116,60 @@ void EventSelectionModule::initialize()
     _met_et = 0.0;
     tree_handler->getTree()->Branch("met_et", &_met_et, "met_et/F");
 
-    _bjorken_x = 0.0;
+    _bjorken_x  = 0.0;
     _bjorken_Q2 = 0.0;
-    _bjorken_y = 0.0;
-    _jb_x = 0.0;
-    _jb_Q2 = 0.0;
+    _bjorken_y  = 0.0;
+    _jb_x       = 0.0;
+    _jb_Q2      = 0.0;
     tree_handler->getTree()->Branch("bjorken_x", &_bjorken_x, "bjorken_x/F");
     tree_handler->getTree()->Branch("bjorken_Q2", &_bjorken_Q2, "bjorken_Q2/F");
     tree_handler->getTree()->Branch("bjorken_y", &_bjorken_y, "bjorken_y/F");
     tree_handler->getTree()->Branch("jb_x", &_jb_x, "jb_x/F");
     tree_handler->getTree()->Branch("jb_Q2", &_jb_Q2, "jb_Q2/F");
-
   }
 
 
   // Initialize the cut flow
 
-  _cut_flow["1: All events"] = 0;
-  _cut_flow["2: MET > 10 GeV"] = 0;
+  _cut_flow["1: All events"]         = 0;
+  _cut_flow["2: MET > 10 GeV"]       = 0;
   _cut_flow["3: Fiducial Jets >= 1"] = 0;
-  _cut_flow["4: Charm Jet == 1"] = 0;
+  _cut_flow["4: Charm Jet == 1"]     = 0;
 
   // Global variables
   _mpi = TDatabasePDG().GetParticle(211)->Mass();
   _mK  = TDatabasePDG().GetParticle(321)->Mass();
-
-
-
 }
 
 void EventSelectionModule::finalize()
 {
   ofstream csvfile;
+
   csvfile.open("cut_flow.csv");
-  
+
   csvfile << "Cut,Yield" << std::endl;
 
-  for (auto& [cut,yield] : _cut_flow) {
+  for (auto&[cut, yield] : _cut_flow) {
     csvfile << "\"" << cut << "\"," << int(yield) << std::endl;
   }
 
   csvfile.close();
-
 }
 
-
-bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
+bool EventSelectionModule::execute(std::map<std::string, std::any> *DataStore)
 {
   auto data = getData();
 
 
   // Compute global DIS variables
   auto dis_variables = DISVariables(getGenParticles());
-  _bjorken_x = dis_variables["x"];
+
+  _bjorken_x  = dis_variables["x"];
   _bjorken_Q2 = dis_variables["Q2"];
-  _bjorken_y = dis_variables["y"];
+  _bjorken_y  = dis_variables["y"];
 
   auto jb_variables = DISJacquetBlondel(getEFlowTracks(), getElectrons(), getPhotons(), getNeutralHadrons());
-  _jb_x = jb_variables["x_JB"];
+  _jb_x  = jb_variables["x_JB"];
   _jb_Q2 = jb_variables["Q2_JB"];
 
 
@@ -195,18 +185,19 @@ bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
   bool passed = true;
 
   // Get the MET object and use it
-  MissingET* MET = nullptr;
+  MissingET *MET = nullptr;
+
   for (int imet = 0; imet < getMET()->GetEntries(); imet++) {
-    MET = static_cast<MissingET*>(getMET()->At(imet));
+    MET = static_cast<MissingET *>(getMET()->At(imet));
   }
-  
+
   if (MET == nullptr) {
     passed = false;
   }
 
   _met_et = MET->MET;
-  
-  if (passed == true && MET->MET > 10.0) {
+
+  if ((passed == true) && (MET->MET > 10.0)) {
     _cut_flow["2: MET > 10 GeV"] += 1;
   } else {
     passed = false;
@@ -258,6 +249,7 @@ bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
 
 
   bool use_kaons = false;
+
   if (DataStore->find("Kaons") != DataStore->end()) {
     // store the number of kaons in the jets
     use_kaons = true;
@@ -265,317 +257,358 @@ bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
 
 
   bool use_electrons = false;
+
   if (DataStore->find("Electrons") != DataStore->end()) {
     // store the number of electrons in the jets
     use_electrons = true;
   }
 
   bool use_muons = false;
+
   if (DataStore->find("Muons") != DataStore->end()) {
     // store the number of muons in the jets
     use_muons = true;
   }
 
 
-  // Loop over tracks in the event; make opposite-sign pairs; compute mass and call them Ks if within some window
+  // Loop over tracks in the event; make opposite-sign pairs; compute mass and
+  // call them Ks if within some window
   // of the Ks0 mass.
 
   // auto particles = getGenParticles();
 
-  std::vector<Track*> all_tracks;
-  //std::vector<GenParticle*> all_tracks;
-  //std::vector<TLorentzVector> all_tracks;
-  for (auto obj_track : *tracks) 
-    {
-      auto track = static_cast<Track*>(obj_track);
-      if (track->PT < 0.1)
-	continue;
-      all_tracks.push_back( track );
-    }
+  std::vector<Track *> all_tracks;
+
+  // std::vector<GenParticle*> all_tracks;
+  // std::vector<TLorentzVector> all_tracks;
+  for (auto obj_track : *tracks)
+  {
+    auto track = static_cast<Track *>(obj_track);
+
+    if (track->PT < 0.1)
+      continue;
+    all_tracks.push_back(track);
+  }
 
 
   // Build all Ks candidates
   std::vector<Candidate> Ks_candidates;
 
   for (int i = 0; i < all_tracks.size(); i++)
+  {
+    for (int j = i + 1; j < all_tracks.size(); j++)
     {
-      for (int j = i + 1; j < all_tracks.size(); j++) 
-	{
-	  auto track1 = all_tracks[i];
-	  auto track2 = all_tracks[j];
+      auto track1 = all_tracks[i];
+      auto track2 = all_tracks[j];
 
-	  if (track1->Charge * track2->Charge != -1)
-	     continue;
+      if (track1->Charge * track2->Charge != -1)
+        continue;
 
-	  // Treat the tracks under the charged pion hypothesis
-	  auto track1P4 = TLorentzVector();
-	  track1P4.SetPtEtaPhiM(track1->PT, track1->Eta, track1->Phi, _mpi);
-	  auto track2P4 = TLorentzVector();
-	  track2P4.SetPtEtaPhiM(track2->PT, track2->Eta, track2->Phi, _mpi);
-	      
-	  // std::cout << "===========================================================" << std::endl;
-	  // track1->P4().Print();
-	  // track2->P4().Print();
-	  
-	  //TLorentzVector Ks_candidate = track1->P4() + track2->P4();
-	  TLorentzVector Ks_candidate = track1P4 + track2P4;
-	      
-	  if ( TMath::Abs(Ks_candidate.M() - 0.497) > 0.250 )
-	    continue;
+      // Treat the tracks under the charged pion hypothesis
+      auto track1P4 = TLorentzVector();
+      track1P4.SetPtEtaPhiM(track1->PT, track1->Eta, track1->Phi, _mpi);
+      auto track2P4 = TLorentzVector();
+      track2P4.SetPtEtaPhiM(track2->PT, track2->Eta, track2->Phi, _mpi);
 
-	  // Spatial coincidence requirement
-	  TVector3 track1_POCA(track1->X, track1->Y, track1->Z);
-	  TVector3 track2_POCA(track2->X, track2->Y, track2->Z);
-	  
-	  auto intertrack_displacement = track1_POCA - track2_POCA;
-	  float intertrack_distance = intertrack_displacement.Mag();
+      // std::cout <<
+      // "===========================================================" <<
+      // std::endl;
+      // track1->P4().Print();
+      // track2->P4().Print();
 
-	  float track1_d0err = track1->ErrorD0;
-	  float track1_z0err = track1->ErrorDZ;
-	  float track2_d0err = track2->ErrorD0;
-	  float track2_z0err = track2->ErrorDZ;
+      // TLorentzVector Ks_candidate = track1->P4() + track2->P4();
+      TLorentzVector Ks_candidate = track1P4 + track2P4;
 
-	  float err_3D = TMath::Sqrt( TMath::Power(track1_d0err,2.0) + TMath::Power(track1_z0err,2.0) +
-				      TMath::Power(track2_d0err,2.0) + TMath::Power(track2_z0err,2.0) );
-	  
-	  float intertrack_distance_signif = intertrack_distance/err_3D;
+      if (TMath::Abs(Ks_candidate.M() - 0.497) > 0.250)
+        continue;
 
-	  // std::cout << " Intertrack distance, error, significance: " << intertrack_distance << " mm" 
-	  // 	    << ", " << err_3D 
-	  // 	    << ", " << intertrack_distance_signif << std::endl;
+      // Spatial coincidence requirement
+      TVector3 track1_POCA(track1->X, track1->Y, track1->Z);
+      TVector3 track2_POCA(track2->X, track2->Y, track2->Z);
 
-	  // To be from a common decay, their displacement significance should be small
+      auto  intertrack_displacement = track1_POCA - track2_POCA;
+      float intertrack_distance     = intertrack_displacement.Mag();
 
-	  if (intertrack_distance_signif > 1.5)
-	    continue;
+      float track1_d0err = track1->ErrorD0;
+      float track1_z0err = track1->ErrorDZ;
+      float track2_d0err = track2->ErrorD0;
+      float track2_z0err = track2->ErrorDZ;
 
-	  // build a new Candidate
-	  Candidate Ks;
-	  Ks.PID = 310;
-	  Ks.Mass = Ks_candidate.M();
-	  Ks.Momentum = Ks_candidate;
-	  Ks.Position = TLorentzVector(track2_POCA + 0.5*intertrack_displacement, 0.0); // midpoint between POCA of two tracks
-	  
+      float err_3D = TMath::Sqrt(TMath::Power(track1_d0err, 2.0) + TMath::Power(track1_z0err, 2.0) +
+                                 TMath::Power(track2_d0err, 2.0) + TMath::Power(track2_z0err, 2.0));
 
-	      
-	  Ks_candidates.push_back(Ks);
-	}
-    }
+      float intertrack_distance_signif = intertrack_distance / err_3D;
+
+      // std::cout << " Intertrack distance, error, significance: " <<
+      // intertrack_distance << " mm"
+      //            << ", " << err_3D
+      //            << ", " << intertrack_distance_signif << std::endl;
+
+      // To be from a common decay, their displacement significance should be
+      // small
+
+      if (intertrack_distance_signif > 1.5)
+        continue;
+
+      // build a new Candidate
+      Candidate Ks;
+      Ks.PID      = 310;
+      Ks.Mass     = Ks_candidate.M();
+      Ks.Momentum = Ks_candidate;
+      Ks.Position = TLorentzVector(track2_POCA + 0.5 * intertrack_displacement, 0.0); //
+                                                                                      //
+                                                                                      // midpoint
+                                                                                      //
+                                                                                      // between
+                                                                                      //
+                                                                                      // POCA
+                                                                                      //
+                                                                                      // of
+                                                                                      //
+                                                                                      // two
+                                                                                      //
+                                                                                      // tracks
 
 
-  // Get Kaons, etc. from the RICH detector
-  std::vector<Track*> mrich_kaons;
-  for (int itrk = 0; itrk < _branch_mRICHTracks->GetEntries(); itrk++) {
-    Track* track = (Track*) _branch_mRICHTracks->At(itrk);
-    if (TMath::Abs(track->PID) == 321) {
-      mrich_kaons.push_back( track );
+      Ks_candidates.push_back(Ks);
     }
   }
 
-  std::vector<Jet*> all_jets;
-  for (int ijet = 0; ijet < getJets()->GetEntries(); ijet++) 
-    {
-      // Take first jet
-      Jet *jet = (Jet*) getJets()->At(ijet);
-      all_jets.push_back(jet);
 
-      _jet_pt.push_back( jet->PT );
-      _jet_eta.push_back( jet->Eta );
-      _jet_flavor.push_back( jet->Flavor );
-      _jet_nconstituents.push_back( jet->Constituents.GetEntries() );
-      // pre-long-lived particle decay optimization
-      //_jet_sip3dtag.push_back( Tagged_sIP3D(jet, *getEFlowTracks(), 3.75, 1.00, 2.0) );
-      // after including long-lived particle decay, optimization
-      //_jet_sip3dtag.push_back( Tagged_sIP3D(jet, *getEFlowTracks(), 2.75, 0.25, 2.0) );
-      // _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *tagging_tracks, 2.75, 0.25, 2.0) );
-      //_jet_sip3dtag.push_back( Tagged_sIP3D(jet, *tagging_tracks, 3.75, 1.00, 2.0) );
+  // Get Kaons, etc. from the RICH detector
+  std::vector<Track *> mrich_kaons;
 
-      // After using the significance of the charm tag yield in 100/fb to optimize the tagging,
-      // and after fixing the PYTHIA ctau_max bug:
-      _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *getEFlowTracks(), 3.00, 0.25, 2.0) );
+  for (int itrk = 0; itrk < _branch_mRICHTracks->GetEntries(); itrk++) {
+    Track *track = (Track *)_branch_mRICHTracks->At(itrk);
 
-
-      // Find all the good flavor-tagging tracks in this jet
-      std::vector<Track*> jet_tracks;
-      for (int itrk = 0; itrk < getEFlowTracks()->GetEntries(); itrk++) {
-	auto track = (Track*) getEFlowTracks()->At(itrk);
-
-      	if (track->P4().DeltaR( jet->P4() ) < 0.5 && IsTaggingTrack(track)) {
-	  jet_tracks.push_back( track );
-	}
-      }
-
-
-
-      // Rank by sIP3D
-      std::sort( jet_tracks.begin( ), jet_tracks.end( ), [ jet ](auto& lhs, const auto& rhs )
-		 {
-		   return sIP3D(jet,lhs) > sIP3D(jet,rhs);
-		 });
-      
-      // store the HIP track information
-      if (jet_tracks.size() > 0) {
-	_jet_t1_sIP3D.push_back( sIP3D(jet, jet_tracks[0]) );
-	_jet_t1_pt.push_back( jet_tracks[0]->PT );
-      } else {
-	_jet_t1_sIP3D.push_back(-999.0);
-	_jet_t1_pt.push_back( -1.0 );
-      }
-      if (jet_tracks.size() > 1) {
-	_jet_t2_sIP3D.push_back( sIP3D(jet, jet_tracks[1]) );
-	_jet_t2_pt.push_back( jet_tracks[1]->PT );
-      } else {
-	_jet_t2_sIP3D.push_back(-999.0);
-	_jet_t2_pt.push_back( -1.0 );
-      }
-      if (jet_tracks.size() > 2) {
-	_jet_t3_sIP3D.push_back( sIP3D(jet, jet_tracks[2]) );
-	_jet_t3_pt.push_back( jet_tracks[2]->PT );
-      } else {
-	_jet_t3_sIP3D.push_back(-999.0);
-	_jet_t3_pt.push_back( -1.0 );
-      }
-      if (jet_tracks.size() > 3) {
-	_jet_t4_sIP3D.push_back( sIP3D(jet, jet_tracks[3]) );
-	_jet_t4_pt.push_back( jet_tracks[3]->PT );
-      } else {
-	_jet_t4_sIP3D.push_back(-999.0);
-	_jet_t4_pt.push_back( -1.0 );
-      }
-
-      if (use_electrons) {
-	_jet_etag.push_back( Tagged_Electron(jet, std::any_cast<std::vector<Track*>>((*DataStore)["Electrons"]), 3.0, 1.0, 1) );
-      } else { 
-	_jet_etag.push_back(0.0);
-      }
-
-
-      if (use_muons) {
-	_jet_mutag.push_back( Tagged_Muon(jet, std::any_cast<std::vector<Track*>>((*DataStore)["Muons"]), 3.0, 1.0, 1) );
-      } else {
-	_jet_mutag.push_back( 0.0 );
-      }
-
-      if (use_kaons) {
-	_jet_ktag.push_back( Tagged_Kaon(jet, std::any_cast<std::vector<Track*>>((*DataStore)["Kaons"]), 3.0, 1.0, 1) );
-      } else {
-	_jet_ktag.push_back( 0.0 );
-      }
-
-      // mRICH Kaon Information
-      
-      // Sort by PT
-      std::sort( mrich_kaons.begin( ), mrich_kaons.end( ), [ ](auto& lhs, const auto& rhs )
-	    {
-	      return lhs->PT > rhs->PT;
-	    });
-
-      if (mrich_kaons.size() > 0) {
-	auto k1 = mrich_kaons[0];
-	_jet_k1_pt.push_back( k1->PT );
-	_jet_k1_sIP3D.push_back( sIP3D(jet, k1) );
-      } else {
-	_jet_k1_pt.push_back( -1.0 );
-	_jet_k1_sIP3D.push_back( -999.0 );
-      }
-
-      if (mrich_kaons.size() > 1) {
-	auto k2 = mrich_kaons[1];
-	_jet_k2_pt.push_back( k2->PT );
-	_jet_k2_sIP3D.push_back( sIP3D(jet, k2) );
-      } else {
-	_jet_k2_pt.push_back( -1.0 );
-	_jet_k2_sIP3D.push_back( -999.0 );
-      }
-
-      TVector3 Ks_sumpt;
-      _jet_Ks_mass.push_back(std::vector<float>());
-      _jet_Ks_p.push_back(std::vector<float>());
-      _jet_Ks_flightlength.push_back(std::vector<float>());
-      _jet_Ks_zhadron.push_back(std::vector<float>());
-      for (auto Ks_candidate : Ks_candidates) {
-	if (Ks_candidate.Position.Rho() < 5) // 5mm minimum displacement from IP 
-	  continue;
-	if (Ks_candidate.Momentum.DeltaR( jet->P4() ) < 0.5) {
-	  
-	  Ks_sumpt += Ks_candidate.Momentum.Vect();
-	  _jet_Ks_mass[ijet].push_back( Ks_candidate.Mass );
-	  _jet_Ks_p[ijet].push_back( Ks_candidate.Momentum.Rho() );
-	  _jet_Ks_flightlength[ijet].push_back( Ks_candidate.Position.Rho() );
-
-	  _jet_Ks_zhadron[ijet].push_back( TMath::Abs((Ks_candidate.Momentum.Vect() * jet->P4().Vect())/jet->P4().Vect().Mag2()) );
-
-	}
-      }
-
-      if (_jet_Ks_zhadron[ijet].size() == 0) {
-	_jet_Ks_zhadron[ijet].push_back(-1.0); // TMVA hates empty vector branches!
-      }
-
-      _jet_Ks_leading_zhadron.push_back( *max_element(_jet_Ks_zhadron[ijet].begin(), _jet_Ks_zhadron[ijet].end()) );
-
-
-      _jet_Ks_sumpt.push_back( Ks_sumpt.Perp() );
-
-      // handle charged kaons
-      _jet_K_zhadron.push_back(std::vector<float>());
-      TVector3 K_sumpt;
-      if (use_kaons) {
-	auto kaon_candidates = std::any_cast<std::vector<Track*>>((*DataStore)["Kaons"]);
-	for (auto kaon : kaon_candidates) {
-	  if (kaon->P4().DeltaR(jet->P4()) < 0.5) {
-	    K_sumpt += kaon->P4().Vect();
-	    _jet_K_zhadron[ijet].push_back( TMath::Abs((kaon->P4().Vect() * jet->P4().Vect())/jet->P4().Vect().Mag2()) );
-	  }
-	}
-      }
-      if (_jet_K_zhadron[ijet].size() == 0) {
-	_jet_K_zhadron[ijet].push_back(-1.0); // TMVA hates empty vector branches!
-      }
-
-      _jet_K_leading_zhadron.push_back( *max_element(_jet_K_zhadron[ijet].begin(), _jet_K_zhadron[ijet].end()) );
-
-      _jet_K_sumpt.push_back( K_sumpt.Perp() );
-
-
-      // Calorimeter energy ratios
-      _jet_ehadoveremratio.push_back( jet->EhadOverEem );
-
-      // Jet charge!
-      float jet_Q = -999.0;
-      float kappa = 0.5;
-      for (auto obj_track : *getEFlowTracks()) {
-	auto track = static_cast<Track*>(obj_track);
-	if (track->P4().DeltaR(jet->P4()) < 0.5) {
-	  if (jet_Q == -999.0) {
-	    jet_Q = 0.0;
-	  }
-	  jet_Q += track->Charge * TMath::Power(track->PT, kappa);
-	}
-      }
-      jet_Q /= TMath::Power(jet->PT, kappa);
-      _jet_charge.push_back( jet_Q );
-
+    if (TMath::Abs(track->PID) == 321) {
+      mrich_kaons.push_back(track);
     }
+  }
+
+  std::vector<Jet *> all_jets;
+
+  for (int ijet = 0; ijet < getJets()->GetEntries(); ijet++)
+  {
+    // Take first jet
+    Jet *jet = (Jet *)getJets()->At(ijet);
+    all_jets.push_back(jet);
+
+    _jet_pt.push_back(jet->PT);
+    _jet_eta.push_back(jet->Eta);
+    _jet_flavor.push_back(jet->Flavor);
+    _jet_nconstituents.push_back(jet->Constituents.GetEntries());
+
+    // pre-long-lived particle decay optimization
+    // _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *getEFlowTracks(), 3.75, 1.00,
+    // 2.0) );
+    // after including long-lived particle decay, optimization
+    // _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *getEFlowTracks(), 2.75, 0.25,
+    // 2.0) );
+    // _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *tagging_tracks, 2.75, 0.25,
+    // 2.0) );
+    // _jet_sip3dtag.push_back( Tagged_sIP3D(jet, *tagging_tracks, 3.75, 1.00,
+    // 2.0) );
+
+    // After using the significance of the charm tag yield in 100/fb to optimize
+    // the tagging,
+    // and after fixing the PYTHIA ctau_max bug:
+    _jet_sip3dtag.push_back(Tagged_sIP3D(jet, *getEFlowTracks(), 3.00, 0.25, 2.0));
+
+
+    // Find all the good flavor-tagging tracks in this jet
+    std::vector<Track *> jet_tracks;
+
+    for (int itrk = 0; itrk < getEFlowTracks()->GetEntries(); itrk++) {
+      auto track = (Track *)getEFlowTracks()->At(itrk);
+
+      if ((track->P4().DeltaR(jet->P4()) < 0.5) && IsTaggingTrack(track)) {
+        jet_tracks.push_back(track);
+      }
+    }
+
+
+    // Rank by sIP3D
+    std::sort(jet_tracks.begin(), jet_tracks.end(), [jet](auto& lhs, const auto& rhs)
+    {
+      return sIP3D(jet, lhs) > sIP3D(jet, rhs);
+    });
+
+    // store the HIP track information
+    if (jet_tracks.size() > 0) {
+      _jet_t1_sIP3D.push_back(sIP3D(jet, jet_tracks[0]));
+      _jet_t1_pt.push_back(jet_tracks[0]->PT);
+    } else {
+      _jet_t1_sIP3D.push_back(-999.0);
+      _jet_t1_pt.push_back(-1.0);
+    }
+
+    if (jet_tracks.size() > 1) {
+      _jet_t2_sIP3D.push_back(sIP3D(jet, jet_tracks[1]));
+      _jet_t2_pt.push_back(jet_tracks[1]->PT);
+    } else {
+      _jet_t2_sIP3D.push_back(-999.0);
+      _jet_t2_pt.push_back(-1.0);
+    }
+
+    if (jet_tracks.size() > 2) {
+      _jet_t3_sIP3D.push_back(sIP3D(jet, jet_tracks[2]));
+      _jet_t3_pt.push_back(jet_tracks[2]->PT);
+    } else {
+      _jet_t3_sIP3D.push_back(-999.0);
+      _jet_t3_pt.push_back(-1.0);
+    }
+
+    if (jet_tracks.size() > 3) {
+      _jet_t4_sIP3D.push_back(sIP3D(jet, jet_tracks[3]));
+      _jet_t4_pt.push_back(jet_tracks[3]->PT);
+    } else {
+      _jet_t4_sIP3D.push_back(-999.0);
+      _jet_t4_pt.push_back(-1.0);
+    }
+
+    if (use_electrons) {
+      _jet_etag.push_back(Tagged_Electron(jet, std::any_cast<std::vector<Track *> >((*DataStore)["Electrons"]), 3.0, 1.0, 1));
+    } else {
+      _jet_etag.push_back(0.0);
+    }
+
+
+    if (use_muons) {
+      _jet_mutag.push_back(Tagged_Muon(jet, std::any_cast<std::vector<Track *> >((*DataStore)["Muons"]), 3.0, 1.0, 1));
+    } else {
+      _jet_mutag.push_back(0.0);
+    }
+
+    if (use_kaons) {
+      _jet_ktag.push_back(Tagged_Kaon(jet, std::any_cast<std::vector<Track *> >((*DataStore)["Kaons"]), 3.0, 1.0, 1));
+    } else {
+      _jet_ktag.push_back(0.0);
+    }
+
+    // mRICH Kaon Information
+
+    // Sort by PT
+    std::sort(mrich_kaons.begin(), mrich_kaons.end(), [](auto& lhs, const auto& rhs)
+    {
+      return lhs->PT > rhs->PT;
+    });
+
+    if (mrich_kaons.size() > 0) {
+      auto k1 = mrich_kaons[0];
+      _jet_k1_pt.push_back(k1->PT);
+      _jet_k1_sIP3D.push_back(sIP3D(jet, k1));
+    } else {
+      _jet_k1_pt.push_back(-1.0);
+      _jet_k1_sIP3D.push_back(-999.0);
+    }
+
+    if (mrich_kaons.size() > 1) {
+      auto k2 = mrich_kaons[1];
+      _jet_k2_pt.push_back(k2->PT);
+      _jet_k2_sIP3D.push_back(sIP3D(jet, k2));
+    } else {
+      _jet_k2_pt.push_back(-1.0);
+      _jet_k2_sIP3D.push_back(-999.0);
+    }
+
+    TVector3 Ks_sumpt;
+    _jet_Ks_mass.push_back(std::vector<float>());
+    _jet_Ks_p.push_back(std::vector<float>());
+    _jet_Ks_flightlength.push_back(std::vector<float>());
+    _jet_Ks_zhadron.push_back(std::vector<float>());
+
+    for (auto Ks_candidate : Ks_candidates) {
+      if (Ks_candidate.Position.Rho() < 5) // 5mm minimum displacement from IP
+        continue;
+
+      if (Ks_candidate.Momentum.DeltaR(jet->P4()) < 0.5) {
+        Ks_sumpt += Ks_candidate.Momentum.Vect();
+        _jet_Ks_mass[ijet].push_back(Ks_candidate.Mass);
+        _jet_Ks_p[ijet].push_back(Ks_candidate.Momentum.Rho());
+        _jet_Ks_flightlength[ijet].push_back(Ks_candidate.Position.Rho());
+
+        _jet_Ks_zhadron[ijet].push_back(TMath::Abs((Ks_candidate.Momentum.Vect() * jet->P4().Vect()) / jet->P4().Vect().Mag2()));
+      }
+    }
+
+    if (_jet_Ks_zhadron[ijet].size() == 0) {
+      _jet_Ks_zhadron[ijet].push_back(-1.0); // TMVA hates empty vector
+                                             // branches!
+    }
+
+    _jet_Ks_leading_zhadron.push_back(*max_element(_jet_Ks_zhadron[ijet].begin(), _jet_Ks_zhadron[ijet].end()));
+
+
+    _jet_Ks_sumpt.push_back(Ks_sumpt.Perp());
+
+    // handle charged kaons
+    _jet_K_zhadron.push_back(std::vector<float>());
+    TVector3 K_sumpt;
+
+    if (use_kaons) {
+      auto kaon_candidates = std::any_cast<std::vector<Track *> >((*DataStore)["Kaons"]);
+
+      for (auto kaon : kaon_candidates) {
+        if (kaon->P4().DeltaR(jet->P4()) < 0.5) {
+          K_sumpt += kaon->P4().Vect();
+          _jet_K_zhadron[ijet].push_back(TMath::Abs((kaon->P4().Vect() * jet->P4().Vect()) / jet->P4().Vect().Mag2()));
+        }
+      }
+    }
+
+    if (_jet_K_zhadron[ijet].size() == 0) {
+      _jet_K_zhadron[ijet].push_back(-1.0); // TMVA hates empty vector branches!
+    }
+
+    _jet_K_leading_zhadron.push_back(*max_element(_jet_K_zhadron[ijet].begin(), _jet_K_zhadron[ijet].end()));
+
+    _jet_K_sumpt.push_back(K_sumpt.Perp());
+
+
+    // Calorimeter energy ratios
+    _jet_ehadoveremratio.push_back(jet->EhadOverEem);
+
+    // Jet charge!
+    float jet_Q = -999.0;
+    float kappa = 0.5;
+
+    for (auto obj_track : *getEFlowTracks()) {
+      auto track = static_cast<Track *>(obj_track);
+
+      if (track->P4().DeltaR(jet->P4()) < 0.5) {
+        if (jet_Q == -999.0) {
+          jet_Q = 0.0;
+        }
+        jet_Q += track->Charge * TMath::Power(track->PT, kappa);
+      }
+    }
+    jet_Q /= TMath::Power(jet->PT, kappa);
+    _jet_charge.push_back(jet_Q);
+  }
 
   _jet_n = _jet_pt.size();
 
-  std::vector<Jet*> fiducial_jets = SelectorFcn<Jet>(all_jets, [](Jet* j){ return (TMath::Abs(j->Eta) < 3.0 && j->PT > 5.0); });
+  std::vector<Jet *> fiducial_jets = SelectorFcn<Jet>(all_jets, [](Jet *j) {
+    return TMath::Abs(j->Eta) < 3.0 && j->PT > 5.0;
+  });
 
-  if (passed == true && fiducial_jets.size() > 0) {
+  if ((passed == true) && (fiducial_jets.size() > 0)) {
     _cut_flow["3: Fiducial Jets >= 1"] += 1;
   } else {
     passed = false;
   }
 
-  //std::vector<Jet*> charmJets = SelectorFcn<Jet>(fiducial_jets, [](Jet* j){ return (j->Flavor == 4); });
-  
-  std::vector<Jet*> charmJets;
+  // std::vector<Jet*> charmJets = SelectorFcn<Jet>(fiducial_jets, [](Jet* j){
+  // return (j->Flavor == 4); });
+
+  std::vector<Jet *> charmJets;
+
   if (DataStore->find("CharmJets") != DataStore->end()) {
-    charmJets = std::any_cast<std::vector<Jet*>>((*DataStore)["CharmJets"]);
+    charmJets = std::any_cast<std::vector<Jet *> >((*DataStore)["CharmJets"]);
   }
 
-  if (passed == true && charmJets.size() > 0) {
+  if ((passed == true) && (charmJets.size() > 0)) {
     _cut_flow["4: Charm Jet == 1"] += 1;
   } else {
     passed = false;
@@ -585,8 +618,8 @@ bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
   // Store charm jet information
   if (passed) {
     for (auto jet : charmJets) {
-      _charmjet_pt.push_back( jet->PT );
-      _charmjet_eta.push_back( jet->Eta );
+      _charmjet_pt.push_back(jet->PT);
+      _charmjet_eta.push_back(jet->Eta);
     }
     _charmjet_n = _charmjet_pt.size();
   }
@@ -594,7 +627,3 @@ bool EventSelectionModule::execute(std::map<std::string, std::any>* DataStore)
 
   return true;
 }
-
-
-
-

--- a/SimpleAnalysis/EventSelectionModule.h
+++ b/SimpleAnalysis/EventSelectionModule.h
@@ -9,83 +9,81 @@
 
 
 class EventSelectionModule : public Module {
+public:
 
- public:
-
-  EventSelectionModule(ExRootTreeReader* data);
+  EventSelectionModule(ExRootTreeReader *data);
 
   ~EventSelectionModule();
 
   void initialize() override;
-  bool execute(std::map<std::string, std::any>* DataStore) override;
+  bool execute(std::map<std::string, std::any> *DataStore) override;
   void finalize() override;
 
- private:
+private:
 
   // Branch variables for storage to disk
-  unsigned int       _charmjet_n;
-  std::vector<float> _charmjet_pt;
-  std::vector<float> _charmjet_eta;
+  unsigned int _charmjet_n;
+  std::vector<float>_charmjet_pt;
+  std::vector<float>_charmjet_eta;
 
-  unsigned int       _jet_n;
-  std::vector<float> _jet_pt;
-  std::vector<float> _jet_eta;
-  std::vector<int>   _jet_flavor;
-  std::vector<int>   _jet_nconstituents;
-  std::vector<int>   _jet_sip3dtag;
-  
+  unsigned int _jet_n;
+  std::vector<float>_jet_pt;
+  std::vector<float>_jet_eta;
+  std::vector<int>_jet_flavor;
+  std::vector<int>_jet_nconstituents;
+  std::vector<int>_jet_sip3dtag;
+
   // kaon information
-  std::vector<int>   _jet_ktag;
-  std::vector<float> _jet_k1_pt;
-  std::vector<float> _jet_k1_sIP3D;
-  std::vector<float> _jet_k2_pt;
-  std::vector<float> _jet_k2_sIP3D;
+  std::vector<int>_jet_ktag;
+  std::vector<float>_jet_k1_pt;
+  std::vector<float>_jet_k1_sIP3D;
+  std::vector<float>_jet_k2_pt;
+  std::vector<float>_jet_k2_sIP3D;
 
-  std::vector<float> _jet_t1_sIP3D;
-  std::vector<float> _jet_t2_sIP3D;
-  std::vector<float> _jet_t3_sIP3D;
-  std::vector<float> _jet_t4_sIP3D;
+  std::vector<float>_jet_t1_sIP3D;
+  std::vector<float>_jet_t2_sIP3D;
+  std::vector<float>_jet_t3_sIP3D;
+  std::vector<float>_jet_t4_sIP3D;
 
-  std::vector<float> _jet_t1_pt;
-  std::vector<float> _jet_t2_pt;
-  std::vector<float> _jet_t3_pt;
-  std::vector<float> _jet_t4_pt;
+  std::vector<float>_jet_t1_pt;
+  std::vector<float>_jet_t2_pt;
+  std::vector<float>_jet_t3_pt;
+  std::vector<float>_jet_t4_pt;
 
 
-  std::vector<int>   _jet_etag;
-  std::vector<int>   _jet_mutag;
-  std::vector<float> _jet_charge;
-  std::vector<std::vector<float>> _jet_Ks_mass;
-  std::vector<std::vector<float>> _jet_Ks_p;
-  std::vector<std::vector<float>> _jet_Ks_flightlength;
-  std::vector<float> _jet_Ks_sumpt;
-  std::vector<float> _jet_K_sumpt;
-  std::vector<std::vector<float>> _jet_Ks_zhadron;
-  std::vector<std::vector<float>> _jet_K_zhadron;
-  std::vector<float> _jet_Ks_leading_zhadron;
-  std::vector<float> _jet_K_leading_zhadron;
-  std::vector<float> _jet_ehadoveremratio;
-  
-  float              _met_et;
+  std::vector<int>_jet_etag;
+  std::vector<int>_jet_mutag;
+  std::vector<float>_jet_charge;
+  std::vector<std::vector<float> >_jet_Ks_mass;
+  std::vector<std::vector<float> >_jet_Ks_p;
+  std::vector<std::vector<float> >_jet_Ks_flightlength;
+  std::vector<float>_jet_Ks_sumpt;
+  std::vector<float>_jet_K_sumpt;
+  std::vector<std::vector<float> >_jet_Ks_zhadron;
+  std::vector<std::vector<float> >_jet_K_zhadron;
+  std::vector<float>_jet_Ks_leading_zhadron;
+  std::vector<float>_jet_K_leading_zhadron;
+  std::vector<float>_jet_ehadoveremratio;
+
+  float _met_et;
 
   // DIS variables
-  float              _bjorken_x;
-  float              _bjorken_Q2;
-  float              _bjorken_y;
-  float              _jb_x;
-  float              _jb_Q2;
+  float _bjorken_x;
+  float _bjorken_Q2;
+  float _bjorken_y;
+  float _jb_x;
+  float _jb_Q2;
 
   // Cut flow
-  //std::vector<std::pair<std::string, int>> _cut_flow;
-  std::map<std::string, int> _cut_flow;
+  // std::vector<std::pair<std::string, int>> _cut_flow;
+  std::map<std::string, int>_cut_flow;
 
   // Global variables
   float _mpi;
   float _mK;
 
   // Branch pointers - only initialize once per run
-  TClonesArray * _branch_mRICHTracks;
-
+  TClonesArray *_branch_mRICHTracks;
 };
 
-#endif
+#endif // ifndef EVENTSELECTIONMODULE_HH

--- a/SimpleAnalysis/EventSelectionModule.h
+++ b/SimpleAnalysis/EventSelectionModule.h
@@ -6,6 +6,10 @@
 #include <vector>
 #include <map>
 #include <utility>
+#include "TMVA/Factory.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/Reader.h"
+#include "TMVA/Tools.h"
 
 
 class EventSelectionModule : public Module {
@@ -35,10 +39,21 @@ private:
 
   // kaon information
   std::vector<int>_jet_ktag;
+
   std::vector<float>_jet_k1_pt;
   std::vector<float>_jet_k1_sIP3D;
   std::vector<float>_jet_k2_pt;
   std::vector<float>_jet_k2_sIP3D;
+
+  std::vector<float>_jet_e1_pt;
+  std::vector<float>_jet_e1_sIP3D;
+  std::vector<float>_jet_e2_pt;
+  std::vector<float>_jet_e2_sIP3D;
+
+  std::vector<float>_jet_mu1_pt;
+  std::vector<float>_jet_mu1_sIP3D;
+  std::vector<float>_jet_mu2_pt;
+  std::vector<float>_jet_mu2_sIP3D;
 
   std::vector<float>_jet_t1_sIP3D;
   std::vector<float>_jet_t2_sIP3D;
@@ -65,6 +80,13 @@ private:
   std::vector<float>_jet_K_leading_zhadron;
   std::vector<float>_jet_ehadoveremratio;
 
+  std::vector<float> _jet_mlp_ktagger;
+  std::vector<float> _jet_mlp_eltagger;
+  std::vector<float> _jet_mlp_mutagger;
+  std::vector<float> _jet_mlp_ip3dtagger;
+  std::vector<float> _jet_mlp_globaltagger;
+
+
   float _met_et;
 
   // DIS variables
@@ -84,6 +106,17 @@ private:
 
   // Branch pointers - only initialize once per run
   TClonesArray *_branch_mRICHTracks;
+
+  // High-level multivariate tagging
+  TMVA::Reader* _mva_reader_ip3dtagger;
+  TMVA::Reader* _mva_reader_ktagger;
+  TMVA::Reader* _mva_reader_eltagger;
+  TMVA::Reader* _mva_reader_mutagger;
+  TMVA::Reader* _mva_reader_globaltagger;
+
+  std::map<TString, Float_t> _mva_inputs_float;
+  std::map<TString, Int_t> _mva_inputs_int;
+
 };
 
 #endif // ifndef EVENTSELECTIONMODULE_HH

--- a/SimpleAnalysis/EventSelectionModule.h
+++ b/SimpleAnalysis/EventSelectionModule.h
@@ -30,6 +30,12 @@ private:
   std::vector<float>_charmjet_pt;
   std::vector<float>_charmjet_eta;
 
+  
+  unsigned int _pid_track_n;
+  std::vector<int>_pid_track_pid;
+  std::vector<float>_pid_track_pt;
+  std::vector<float>_pid_track_eta;
+
   unsigned int _jet_n;
   std::vector<float>_jet_pt;
   std::vector<float>_jet_eta;
@@ -106,6 +112,9 @@ private:
 
   // Branch pointers - only initialize once per run
   TClonesArray *_branch_mRICHTracks;
+  TClonesArray *_branch_barrelDircTracks;
+  TClonesArray *_branch_dRICHagTracks;
+  TClonesArray *_branch_dRICHcfTracks;
 
   // High-level multivariate tagging
   TMVA::Reader* _mva_reader_ip3dtagger;

--- a/SimpleAnalysis/Makefile
+++ b/SimpleAnalysis/Makefile
@@ -1,8 +1,8 @@
 #delphes_path = $(DELPHES_PATH)
 CXX = g++
-CXXFLAGS = -std=c++17 $(shell root-config --cflags --ldflags --libs) -lEG
+CXXFLAGS = -std=c++17 $(shell root-config --cflags --ldflags --libs) -lEG -lTMVA
 CFILES   = $(wildcard *.cc)
-INCLUDE  = -I$(DELPHES_PATH)
+INCLUDE  = -I$(DELPHES_PATH) 
 LIBS     = -L$(DELPHES_PATH) -lDelphes
 
 .PHONY: build check-env

--- a/SimpleAnalysis/mva_taggers/TMVAClassification_CharmETagger.weights.xml
+++ b/SimpleAnalysis/mva_taggers/TMVAClassification_CharmETagger.weights.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::CharmETagger">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.18/04 [397828]"/>
+    <Info name="Creator" value="ssekula"/>
+    <Info name="Date" value="Wed Sep 16 14:13:52 2020"/>
+    <Info name="Host" value="Linux lcgapp-centos7-x86-64-32.cern.ch 3.10.0-957.21.3.el7.x86_64 #1 SMP Tue Jun 18 16:35:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/scratch/users/ssekula/EIC/delphes_EIC/SimpleAnalysis/scripts"/>
+    <Info name="Training events" value="110000"/>
+    <Info name="TrainingTime" value="6.24616713e+02"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">1000</Option>
+    <Option name="HiddenLayers" modified="Yes">N+12</Option>
+    <Option name="NeuronType" modified="Yes">ReLU</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">Norm</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="4">
+    <Variable VarIndex="0" Expression="jet_e1_pt" Label="jet_e1_pt" Title="jet_e1_pt" Unit="" Internal="jet_e1_pt" Type="F" Min="-1.00000000e+00" Max="2.96693306e+01"/>
+    <Variable VarIndex="1" Expression="jet_e1_sIP3D" Label="jet_e1_sIP3D" Title="jet_e1_sIP3D" Unit="" Internal="jet_e1_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.49691208e+02"/>
+    <Variable VarIndex="2" Expression="jet_e2_pt" Label="jet_e2_pt" Title="jet_e2_pt" Unit="" Internal="jet_e2_pt" Type="F" Min="-1.00000000e+00" Max="1.25466499e+01"/>
+    <Variable VarIndex="3" Expression="jet_e2_sIP3D" Label="jet_e2_sIP3D" Title="jet_e2_sIP3D" Unit="" Internal="jet_e2_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.39225449e+02"/>
+  </Variables>
+  <Spectators NSpec="4">
+    <Spectator SpecIndex="0" Expression="jet_pt" Label="jet_pt" Title="jet_pt" Unit="" Internal="jet_pt" Type="F" Min="5.00084496e+00" Max="5.47973328e+01"/>
+    <Spectator SpecIndex="1" Expression="jet_eta" Label="jet_eta" Title="jet_eta" Unit="" Internal="jet_eta" Type="F" Min="-1.20925403e+00" Max="2.99968314e+00"/>
+    <Spectator SpecIndex="2" Expression="jet_flavor" Label="jet_flavor" Title="jet_flavor" Unit="" Internal="jet_flavor" Type="F" Min="0.00000000e+00" Max="2.10000000e+01"/>
+    <Spectator SpecIndex="3" Expression="met_et" Label="met_et" Title="met_et" Unit="" Internal="met_et" Type="F" Min="1.00000010e+01" Max="5.47714386e+01"/>
+  </Spectators>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="4">
+          <Input Type="Variable" Label="jet_e1_pt" Expression="jet_e1_pt"/>
+          <Input Type="Variable" Label="jet_e1_sIP3D" Expression="jet_e1_sIP3D"/>
+          <Input Type="Variable" Label="jet_e2_pt" Expression="jet_e2_pt"/>
+          <Input Type="Variable" Label="jet_e2_sIP3D" Expression="jet_e2_sIP3D"/>
+        </Input>
+        <Output NOutputs="4">
+          <Output Type="Variable" Label="jet_e1_pt" Expression="jet_e1_pt"/>
+          <Output Type="Variable" Label="jet_e1_sIP3D" Expression="jet_e1_sIP3D"/>
+          <Output Type="Variable" Label="jet_e2_pt" Expression="jet_e2_pt"/>
+          <Output Type="Variable" Label="jet_e2_sIP3D" Expression="jet_e2_sIP3D"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="1.5821342468261719e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4584721374511719e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="1.1581114768981934e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.0234701538085938e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="2.9669330596923828e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4969120788574219e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="1.2546649932861328e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.3922544860839844e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="2.9669330596923828e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4969120788574219e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="1.2546649932861328e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.3922544860839844e+02"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="5">
+        <Neuron NSynapses="16">
+          -1.3625761813427153e+00 2.1456174479628705e+00 -1.0285752599634949e-01 1.3997136446500003e+00 8.9576078237702639e-01 -1.2784997171739221e+00 6.8863031075299633e-02 3.1298177434610195e+00 -5.5885278899843427e-01 -7.0706520993349634e-02 -4.2728310229580575e-02 -3.3314372272286602e-01 -5.9476015615176969e-01 -1.1701933978993895e+00 6.3617310698066282e-03 4.8048037162486351e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          1.6370874429655664e+00 1.5043259510038594e+00 8.2005168374985882e+00 4.5016500963171788e+00 2.1185801829801934e-01 -7.1932134772909329e-01 1.6006010819255001e+00 4.8958447783681430e-01 -5.7717383974343894e-01 -1.5864131925255931e-01 1.5595119466737705e+01 -1.4926957235328051e+00 -9.2371300997710981e-01 5.3084389162912577e+00 4.0005237491221812e-01 1.8661005533307211e+01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          5.6399353627101922e-01 1.2733402379673567e-01 1.0970343304309442e-01 -3.0039299386947860e-01 -8.1793689872850517e-01 1.6095990075520281e+00 -1.3050701799269290e-01 -2.0876647381468913e-01 2.2469817194126671e+00 1.8448504428600858e+00 2.6515337511554260e-01 1.6992220906638131e+00 -8.2162271572690959e-02 -6.4632082897326346e-02 8.0775869107098586e-01 2.2668366640524390e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          2.2574928661779192e+00 1.2689076088465412e+00 5.6492858742473784e+00 3.4764448990772525e+00 -1.7459800246807233e-01 1.5922030965535274e+00 -1.2871632468733751e+00 -2.1234229603877410e+00 -1.9037803057829752e-01 -1.2168118404377390e+00 1.0399714902609587e+00 2.6764870197979179e-01 -9.7425822469526557e-01 3.3015416157498696e+00 -2.2047314959672826e-01 1.8113144487310653e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          7.4678442268651568e-01 -7.3276591581318506e-01 -2.1380482722283469e+00 -9.1861668116962070e-01 1.2116324775883376e-01 -1.0567661691718286e+00 -1.5966699876996215e+00 -2.0969206765358628e-01 4.7500778199875437e-01 3.1508059548586131e-01 -1.6190032363336293e+00 1.2249831105199158e-01 -2.5748936623968595e+00 -2.7783143773026646e+00 6.7057592908006314e-01 -1.9481209538214883e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="17">
+        <Neuron NSynapses="1">
+          1.4156012767635029e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          4.0321562175167058e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.1654157825409044e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.9096691631998839e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.5432326626289072e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.7079320286253845e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.4240404228576339e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.7021103950523113e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.1363263182974719e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.0602345571319916e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -6.7276224445069115e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          9.4895101174640961e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.1467960402383269e-13 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -6.1263612759310746e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.4836578819147951e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          5.3820903793420474e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.3985143503961051e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/SimpleAnalysis/mva_taggers/TMVAClassification_CharmGlobalTagger.weights.xml
+++ b/SimpleAnalysis/mva_taggers/TMVAClassification_CharmGlobalTagger.weights.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::CharmGlobalTagger">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.18/04 [397828]"/>
+    <Info name="Creator" value="ssekula"/>
+    <Info name="Date" value="Wed Sep 16 15:24:41 2020"/>
+    <Info name="Host" value="Linux lcgapp-centos7-x86-64-32.cern.ch 3.10.0-957.21.3.el7.x86_64 #1 SMP Tue Jun 18 16:35:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/scratch/users/ssekula/EIC/delphes_EIC/SimpleAnalysis/scripts"/>
+    <Info name="Training events" value="110000"/>
+    <Info name="TrainingTime" value="6.12606717e+02"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">1000</Option>
+    <Option name="HiddenLayers" modified="Yes">N+8</Option>
+    <Option name="NeuronType" modified="Yes">ReLU</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">Norm</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="4">
+    <Variable VarIndex="0" Expression="jet_mlp_ip3dtagger" Label="jet_mlp_ip3dtagger" Title="jet_mlp_ip3dtagger" Unit="" Internal="jet_mlp_ip3dtagger" Type="F" Min="5.74266460e-06" Max="1.00000000e+00"/>
+    <Variable VarIndex="1" Expression="jet_mlp_ktagger" Label="jet_mlp_ktagger" Title="jet_mlp_ktagger" Unit="" Internal="jet_mlp_ktagger" Type="F" Min="2.52261205e-04" Max="9.99948680e-01"/>
+    <Variable VarIndex="2" Expression="jet_mlp_eltagger" Label="jet_mlp_eltagger" Title="jet_mlp_eltagger" Unit="" Internal="jet_mlp_eltagger" Type="F" Min="1.33872638e-03" Max="9.95905161e-01"/>
+    <Variable VarIndex="3" Expression="jet_mlp_mutagger" Label="jet_mlp_mutagger" Title="jet_mlp_mutagger" Unit="" Internal="jet_mlp_mutagger" Type="F" Min="8.39136774e-05" Max="9.90936816e-01"/>
+  </Variables>
+  <Spectators NSpec="4">
+    <Spectator SpecIndex="0" Expression="jet_pt" Label="jet_pt" Title="jet_pt" Unit="" Internal="jet_pt" Type="F" Min="5.00084496e+00" Max="5.47973328e+01"/>
+    <Spectator SpecIndex="1" Expression="jet_eta" Label="jet_eta" Title="jet_eta" Unit="" Internal="jet_eta" Type="F" Min="-1.20925403e+00" Max="2.99968314e+00"/>
+    <Spectator SpecIndex="2" Expression="jet_flavor" Label="jet_flavor" Title="jet_flavor" Unit="" Internal="jet_flavor" Type="F" Min="0.00000000e+00" Max="2.10000000e+01"/>
+    <Spectator SpecIndex="3" Expression="met_et" Label="met_et" Title="met_et" Unit="" Internal="met_et" Type="F" Min="1.00000010e+01" Max="5.47714386e+01"/>
+  </Spectators>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="4">
+          <Input Type="Variable" Label="jet_mlp_ip3dtagger" Expression="jet_mlp_ip3dtagger"/>
+          <Input Type="Variable" Label="jet_mlp_ktagger" Expression="jet_mlp_ktagger"/>
+          <Input Type="Variable" Label="jet_mlp_eltagger" Expression="jet_mlp_eltagger"/>
+          <Input Type="Variable" Label="jet_mlp_mutagger" Expression="jet_mlp_mutagger"/>
+        </Input>
+        <Output NOutputs="4">
+          <Output Type="Variable" Label="jet_mlp_ip3dtagger" Expression="jet_mlp_ip3dtagger"/>
+          <Output Type="Variable" Label="jet_mlp_ktagger" Expression="jet_mlp_ktagger"/>
+          <Output Type="Variable" Label="jet_mlp_eltagger" Expression="jet_mlp_eltagger"/>
+          <Output Type="Variable" Label="jet_mlp_mutagger" Expression="jet_mlp_mutagger"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="2.8208752628415823e-03" Max="1.0000000000000000e+00"/>
+          <Range Index="1" Min="3.7696950603276491e-03" Max="9.9994868040084839e-01"/>
+          <Range Index="2" Min="8.4095066413283348e-03" Max="9.9590516090393066e-01"/>
+          <Range Index="3" Min="6.7438180558383465e-03" Max="9.9093681573867798e-01"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="5.7426645980740432e-06" Max="1.0000000000000000e+00"/>
+          <Range Index="1" Min="2.5226120487786829e-04" Max="9.9967163801193237e-01"/>
+          <Range Index="2" Min="1.3387263752520084e-03" Max="9.0738779306411743e-01"/>
+          <Range Index="3" Min="8.3913677372038364e-05" Max="9.5204073190689087e-01"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="5.7426645980740432e-06" Max="1.0000000000000000e+00"/>
+          <Range Index="1" Min="2.5226120487786829e-04" Max="9.9994868040084839e-01"/>
+          <Range Index="2" Min="1.3387263752520084e-03" Max="9.9590516090393066e-01"/>
+          <Range Index="3" Min="8.3913677372038364e-05" Max="9.9093681573867798e-01"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="5">
+        <Neuron NSynapses="12">
+          -1.5276635443620545e+00 1.0698843277122991e+00 9.2927805373642458e-01 1.9258056337815552e+00 -2.3657538214103693e+00 -1.0066951559307786e+00 -7.4000759755107381e-01 1.6473978997669716e+00 -2.5264532650783567e+00 -9.4468716923755309e+00 -4.9839357202640375e+00 -2.5247036875321180e+00 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -3.0989726760094540e+00 5.7699059019590729e-02 1.7077963878030036e+00 1.4204571465279869e+00 2.9233379376827806e-01 1.2324699852392789e+00 2.0686353609277905e-01 4.9182648263154244e-01 -2.6673754115292434e+00 -3.3194063239614486e+00 5.6969724451909975e-01 8.3400250456672165e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -2.9628032990202748e+00 -3.2483376957078997e-01 2.2506076494539071e+00 -5.6586590896235367e-01 7.6052210195442990e-02 5.2058135366143576e-01 6.5163239819566177e-01 1.8359436193703602e+00 -2.9138547628162339e+00 -2.0237243244226981e+00 9.5110507861379456e-01 -5.8317910362198255e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -1.1750652184571784e+00 1.7300512978080309e+00 -1.3842482186721865e+00 4.8808489690983681e-01 1.5563784593395260e+00 1.2909183455724513e+00 1.8406750686175344e+00 1.2787247905004648e+00 -3.4794002856713382e+00 -1.8722134103653421e-01 -7.0993878890510023e-02 -1.4143256743197810e-01 
+        </Neuron>
+        <Neuron NSynapses="12">
+          -6.6260960291489850e+00 8.7485131826471096e-01 2.1050450547148554e+00 1.8320863313667026e+00 -1.7383168550619501e+00 4.9792931203670981e-01 -1.8994155690653836e+00 -1.4358167974788738e+00 -8.1999838651478925e+00 -1.3028975397469299e+01 -3.4843040119881858e+00 -1.6229455121934817e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="13">
+        <Neuron NSynapses="1">
+          -4.7516163722892601e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          4.6496372123376906e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.0147709529589020e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.4765617438612042e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          8.0609712079017581e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.1992832371328916e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          8.0089461454707342e-02 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -7.2876101396300053e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -9.2010708931165552e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.3123551174481494e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -9.3450564346516396e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -5.4724283318912936e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -7.4662640350266518e-01 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/SimpleAnalysis/mva_taggers/TMVAClassification_CharmIP3DTagger.weights.xml
+++ b/SimpleAnalysis/mva_taggers/TMVAClassification_CharmIP3DTagger.weights.xml
@@ -1,0 +1,244 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::CharmIP3DTagger">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.18/04 [397828]"/>
+    <Info name="Creator" value="ssekula"/>
+    <Info name="Date" value="Wed Sep 16 14:32:49 2020"/>
+    <Info name="Host" value="Linux lcgapp-centos7-x86-64-32.cern.ch 3.10.0-957.21.3.el7.x86_64 #1 SMP Tue Jun 18 16:35:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/scratch/users/ssekula/EIC/delphes_EIC/SimpleAnalysis/scripts"/>
+    <Info name="Training events" value="110000"/>
+    <Info name="TrainingTime" value="1.12024572e+03"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">1000</Option>
+    <Option name="HiddenLayers" modified="Yes">N+16</Option>
+    <Option name="NeuronType" modified="Yes">ReLU</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">Norm</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="8">
+    <Variable VarIndex="0" Expression="jet_t1_pt" Label="jet_t1_pt" Title="jet_t1_pt" Unit="" Internal="jet_t1_pt" Type="F" Min="-1.00000000e+00" Max="3.67092590e+01"/>
+    <Variable VarIndex="1" Expression="jet_t1_sIP3D" Label="jet_t1_sIP3D" Title="jet_t1_sIP3D" Unit="" Internal="jet_t1_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.49952637e+02"/>
+    <Variable VarIndex="2" Expression="jet_t2_pt" Label="jet_t2_pt" Title="jet_t2_pt" Unit="" Internal="jet_t2_pt" Type="F" Min="-1.00000000e+00" Max="3.53610954e+01"/>
+    <Variable VarIndex="3" Expression="jet_t2_sIP3D" Label="jet_t2_sIP3D" Title="jet_t2_sIP3D" Unit="" Internal="jet_t2_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.42877365e+02"/>
+    <Variable VarIndex="4" Expression="jet_t3_pt" Label="jet_t3_pt" Title="jet_t3_pt" Unit="" Internal="jet_t3_pt" Type="F" Min="-1.00000000e+00" Max="3.34995003e+01"/>
+    <Variable VarIndex="5" Expression="jet_t3_sIP3D" Label="jet_t3_sIP3D" Title="jet_t3_sIP3D" Unit="" Internal="jet_t3_sIP3D" Type="F" Min="-1.99000000e+02" Max="6.62740021e+01"/>
+    <Variable VarIndex="6" Expression="jet_t4_pt" Label="jet_t4_pt" Title="jet_t4_pt" Unit="" Internal="jet_t4_pt" Type="F" Min="-1.00000000e+00" Max="3.03219337e+01"/>
+    <Variable VarIndex="7" Expression="jet_t4_sIP3D" Label="jet_t4_sIP3D" Title="jet_t4_sIP3D" Unit="" Internal="jet_t4_sIP3D" Type="F" Min="-1.99000000e+02" Max="3.92929344e+01"/>
+  </Variables>
+  <Spectators NSpec="4">
+    <Spectator SpecIndex="0" Expression="jet_pt" Label="jet_pt" Title="jet_pt" Unit="" Internal="jet_pt" Type="F" Min="5.00084496e+00" Max="5.47973328e+01"/>
+    <Spectator SpecIndex="1" Expression="jet_eta" Label="jet_eta" Title="jet_eta" Unit="" Internal="jet_eta" Type="F" Min="-1.20925403e+00" Max="2.99968314e+00"/>
+    <Spectator SpecIndex="2" Expression="jet_flavor" Label="jet_flavor" Title="jet_flavor" Unit="" Internal="jet_flavor" Type="F" Min="0.00000000e+00" Max="2.10000000e+01"/>
+    <Spectator SpecIndex="3" Expression="met_et" Label="met_et" Title="met_et" Unit="" Internal="met_et" Type="F" Min="1.00000010e+01" Max="5.47714386e+01"/>
+  </Spectators>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="8">
+          <Input Type="Variable" Label="jet_t1_pt" Expression="jet_t1_pt"/>
+          <Input Type="Variable" Label="jet_t1_sIP3D" Expression="jet_t1_sIP3D"/>
+          <Input Type="Variable" Label="jet_t2_pt" Expression="jet_t2_pt"/>
+          <Input Type="Variable" Label="jet_t2_sIP3D" Expression="jet_t2_sIP3D"/>
+          <Input Type="Variable" Label="jet_t3_pt" Expression="jet_t3_pt"/>
+          <Input Type="Variable" Label="jet_t3_sIP3D" Expression="jet_t3_sIP3D"/>
+          <Input Type="Variable" Label="jet_t4_pt" Expression="jet_t4_pt"/>
+          <Input Type="Variable" Label="jet_t4_sIP3D" Expression="jet_t4_sIP3D"/>
+        </Input>
+        <Output NOutputs="8">
+          <Output Type="Variable" Label="jet_t1_pt" Expression="jet_t1_pt"/>
+          <Output Type="Variable" Label="jet_t1_sIP3D" Expression="jet_t1_sIP3D"/>
+          <Output Type="Variable" Label="jet_t2_pt" Expression="jet_t2_pt"/>
+          <Output Type="Variable" Label="jet_t2_sIP3D" Expression="jet_t2_sIP3D"/>
+          <Output Type="Variable" Label="jet_t3_pt" Expression="jet_t3_pt"/>
+          <Output Type="Variable" Label="jet_t3_sIP3D" Expression="jet_t3_sIP3D"/>
+          <Output Type="Variable" Label="jet_t4_pt" Expression="jet_t4_pt"/>
+          <Output Type="Variable" Label="jet_t4_sIP3D" Expression="jet_t4_sIP3D"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="2.4421077728271484e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4933363342285156e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="2.0167058944702148e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.2377681732177734e+02"/>
+          <Range Index="4" Min="-1.0000000000000000e+00" Max="2.5474119186401367e+01"/>
+          <Range Index="5" Min="-1.9900000000000000e+02" Max="6.6274002075195312e+01"/>
+          <Range Index="6" Min="-1.0000000000000000e+00" Max="2.0874671936035156e+01"/>
+          <Range Index="7" Min="-1.9900000000000000e+02" Max="3.9292934417724609e+01"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.6709259033203125e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4995263671875000e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="3.5361095428466797e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4287736511230469e+02"/>
+          <Range Index="4" Min="-1.0000000000000000e+00" Max="3.3499500274658203e+01"/>
+          <Range Index="5" Min="-1.9900000000000000e+02" Max="6.2181468963623047e+01"/>
+          <Range Index="6" Min="-1.0000000000000000e+00" Max="3.0321933746337891e+01"/>
+          <Range Index="7" Min="-1.9900000000000000e+02" Max="2.4857978820800781e+00"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.6709259033203125e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4995263671875000e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="3.5361095428466797e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4287736511230469e+02"/>
+          <Range Index="4" Min="-1.0000000000000000e+00" Max="3.3499500274658203e+01"/>
+          <Range Index="5" Min="-1.9900000000000000e+02" Max="6.6274002075195312e+01"/>
+          <Range Index="6" Min="-1.0000000000000000e+00" Max="3.0321933746337891e+01"/>
+          <Range Index="7" Min="-1.9900000000000000e+02" Max="3.9292934417724609e+01"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="9">
+        <Neuron NSynapses="24">
+          7.3735360977926800e-01 2.7541776633317601e+00 1.3947130984200042e+00 1.5491200188555410e+00 -1.5307743560620657e+00 3.4176702101334921e-01 -3.1780054062919388e-01 -9.5995512932893390e-01 -5.3355863845066009e-01 -3.7966537004345158e-01 1.2677806856232064e-02 -1.3546936698256110e-01 5.9150970832906291e-01 1.3559915933118838e-01 3.3675155562287805e-02 1.4252228809140899e+00 1.4684289506329978e-01 2.6351639265925404e+00 1.6624738373700745e-01 2.0574561224527210e+00 -3.2322192378342152e-01 -1.1796046555959856e-01 3.0316775956445250e+00 6.0773874060249110e-02 
+        </Neuron>
+        <Neuron NSynapses="24">
+          -1.1369666140072995e+01 -7.8431244301981617e-01 1.2076711228407389e+00 -1.0754988122112996e+00 -3.5129658992581994e+00 -2.9863863819103165e-01 -9.5200132508731647e-02 8.3296667736402359e+00 5.9617755369726222e-01 -1.7853597533801506e+00 -6.2683018351004072e-01 -4.6035517872959841e-01 -2.7492614309960821e+01 2.8306563061280141e+01 -6.1914584495933456e+00 2.6162371874900723e+00 1.5821959077500720e+00 1.9227581466936903e+00 3.3013316530325461e+01 1.5855841440903942e+00 -7.4630326125770807e-01 -2.6187824717342187e+00 3.5746030784121691e-01 -1.5518678880876521e+01 
+        </Neuron>
+        <Neuron NSynapses="24">
+          8.3087237373834755e-01 1.4072010576785319e+00 1.7911256130289719e+00 1.5677068377883274e+00 -1.3830739216616422e-01 1.3506246224416033e-01 -5.6148182495695684e-02 -2.8760121168439012e-01 -1.6648245787378319e-01 2.3075524493922592e-01 6.3778093728840912e-02 9.5480607088732816e-01 7.6015374814626024e-01 1.4925404357025843e-01 -3.0268152527445541e-01 2.6198333958931461e+00 3.9328625313953575e-01 9.9787006328504069e-01 5.7622226449499436e-02 -7.5022791920871357e-01 7.6750845089554787e-01 -5.0790463230818017e-01 -4.0478801693956379e-01 1.1721228638774019e-01 
+        </Neuron>
+        <Neuron NSynapses="24">
+          1.1653433610321853e+01 1.2722393272050940e+00 1.1399959881683872e+00 -3.4741143464634805e-01 -1.0387395695635981e+00 -1.4753907455485495e+01 7.0681905014509177e+00 -3.4741689201158382e-01 1.0727729385878929e+01 -3.6223137669498190e-01 -6.6319406582740659e-01 -6.2306346554579206e-01 -3.0751942381519517e+00 9.7838471018715845e-02 -4.3052126827432124e-01 -2.9415466222629805e+00 -2.0510866194161719e+00 -2.6882008194018114e+00 -5.6670191934756066e-02 -7.1289820294889150e-01 1.6343820178881288e+00 -1.5041697373944829e+00 -1.1708987103363369e+00 1.2909209409584692e+01 
+        </Neuron>
+        <Neuron NSynapses="24">
+          6.3546414035358323e-01 -1.8573953523261939e+00 -8.3658435729704317e-01 1.2064089854525871e-01 -6.8700091625408388e-01 5.9471223324239064e-01 6.3664078831247939e-01 2.7034817483359697e-01 -2.6037125985383121e+00 2.0341417657989607e+00 1.0388504735989045e-01 -3.4207839887688807e-01 2.5691298496823561e-01 9.9543074738991072e-02 1.1261703470145054e-01 5.0771132798193397e-01 1.4379726162360857e+00 2.7409431921361910e-01 4.0619303263004294e-02 1.6133666764079482e+00 3.5722214914858341e-01 -2.0436164700941348e-01 1.0844745144447974e+00 -7.8005592102301291e-02 
+        </Neuron>
+        <Neuron NSynapses="24">
+          -7.8634757362627117e-01 -2.3332333473496773e-02 -7.0132394995090441e-01 1.8024610851186929e+00 1.4454336610334013e+00 -5.7508595850431066e+00 -5.2616592477521058e+00 -7.5995562013055365e-02 8.5318302871649387e-01 4.9260645208867784e+00 1.8760645718306080e+01 -1.3567471347118338e+00 2.4292897274281117e+01 2.4407139691262365e-02 -6.8555026250509910e-01 1.4516514871666786e+00 2.6127933189058803e+00 -2.0509817406933082e+00 -6.6194511121410463e-02 8.2404038377632227e-01 1.6136076515540481e+00 4.2703673481436466e-01 -2.0892846161886711e-01 -7.2922090934959387e+00 
+        </Neuron>
+        <Neuron NSynapses="24">
+          -5.0866343222358390e-01 1.2178355217188077e+00 1.5444163367204011e+00 -4.5535200731661246e-01 9.1489955042481974e-01 -1.0877156970170489e-01 5.1538479632336986e-01 -1.7892619026995299e-01 -6.7129698135283278e-01 1.1125983886928474e+00 -1.0468294788663927e-01 7.4633899337017529e-01 1.0628989538730242e+00 2.3406742705005362e-01 9.6572000687698542e-02 -7.7638834338194163e-01 2.2219436219986570e+00 7.3545238865521867e-01 8.4417837351835837e-03 9.6229461513107806e-01 1.0037697488442063e+00 -6.7628218960559703e-03 -2.5685977504866098e-01 3.8587856497940928e-02 
+        </Neuron>
+        <Neuron NSynapses="24">
+          -2.6900138837462884e-01 -5.7732354778082884e-01 1.1058346777792289e+00 1.0133500334421177e+00 5.6555658973137579e-01 1.6041776459836406e+01 5.8528497177828349e+00 1.3199807200501604e-01 7.1724752152513638e-01 1.6063775553610649e+00 -3.8538865440455691e-02 -1.2425272110263526e+00 -6.4211923519680558e-01 -5.4969811843386056e-02 5.4080473704402943e+00 -9.5394019572835265e-01 7.6614184521464324e-01 -7.1365559430837577e-01 3.8085778556836503e-03 1.4112495881189828e+00 -3.6745278351008892e-01 -1.6385598230331064e-01 -1.0558740243694571e+00 6.4694146456537904e+00 
+        </Neuron>
+        <Neuron NSynapses="24">
+          8.9522706184579059e-01 9.7247644284020873e-01 -4.3970217597083872e-01 -7.8360566419806221e-01 -3.2971733002183821e+00 -3.5936944437867715e+00 -1.3662367520994223e+00 -3.4700846199074444e+00 -4.0513995874578681e+00 -6.1193109776892807e-01 -9.0256824673994824e+00 -2.4262727629970198e+00 -4.3002200833619533e+00 -4.3137630277799737e+00 -1.9593022836082385e+00 -7.8698292139153792e-01 6.1345394860114955e-01 1.0785211455520582e+00 -4.8098904430034928e+00 -5.0296117931430384e-01 -1.9367150366306305e+00 -1.6617550670040315e+00 1.4780403966746898e+00 7.7587518689505669e-02 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="25">
+        <Neuron NSynapses="1">
+          -2.4936308887454266e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.3753326771045407e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.7223511481586211e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.7333709170177807e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          2.2824287846291086e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.9553035304919151e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.3955858003504595e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          2.6285499226644964e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.9962848291231703e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.3444119974505324e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          3.9403606679703773e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          4.3109661599427260e-03 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.6807676923105590e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.5135263824348204e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.4270199968165704e-02 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.7637793344956461e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          8.8615230575922166e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -6.8957372651679238e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.5251396298787627e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.1263559048188476e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          8.4609902743250132e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          8.1998712103755633e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.8350055303052414e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.2747633478656666e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.9940454334782705e-01 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/SimpleAnalysis/mva_taggers/TMVAClassification_CharmKTagger.weights.xml
+++ b/SimpleAnalysis/mva_taggers/TMVAClassification_CharmKTagger.weights.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::CharmKTagger">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.18/04 [397828]"/>
+    <Info name="Creator" value="ssekula"/>
+    <Info name="Date" value="Wed Sep 16 14:43:39 2020"/>
+    <Info name="Host" value="Linux lcgapp-centos7-x86-64-32.cern.ch 3.10.0-957.21.3.el7.x86_64 #1 SMP Tue Jun 18 16:35:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/scratch/users/ssekula/EIC/delphes_EIC/SimpleAnalysis/scripts"/>
+    <Info name="Training events" value="110000"/>
+    <Info name="TrainingTime" value="6.36755750e+02"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">1000</Option>
+    <Option name="HiddenLayers" modified="Yes">N+12</Option>
+    <Option name="NeuronType" modified="Yes">ReLU</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">Norm</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="4">
+    <Variable VarIndex="0" Expression="jet_k1_pt" Label="jet_k1_pt" Title="jet_k1_pt" Unit="" Internal="jet_k1_pt" Type="F" Min="-1.00000000e+00" Max="3.34446716e+01"/>
+    <Variable VarIndex="1" Expression="jet_k1_sIP3D" Label="jet_k1_sIP3D" Title="jet_k1_sIP3D" Unit="" Internal="jet_k1_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.48688217e+02"/>
+    <Variable VarIndex="2" Expression="jet_k2_pt" Label="jet_k2_pt" Title="jet_k2_pt" Unit="" Internal="jet_k2_pt" Type="F" Min="-1.00000000e+00" Max="3.07556400e+01"/>
+    <Variable VarIndex="3" Expression="jet_k2_sIP3D" Label="jet_k2_sIP3D" Title="jet_k2_sIP3D" Unit="" Internal="jet_k2_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.45901047e+02"/>
+  </Variables>
+  <Spectators NSpec="4">
+    <Spectator SpecIndex="0" Expression="jet_pt" Label="jet_pt" Title="jet_pt" Unit="" Internal="jet_pt" Type="F" Min="5.00084496e+00" Max="5.47973328e+01"/>
+    <Spectator SpecIndex="1" Expression="jet_eta" Label="jet_eta" Title="jet_eta" Unit="" Internal="jet_eta" Type="F" Min="-1.20925403e+00" Max="2.99968314e+00"/>
+    <Spectator SpecIndex="2" Expression="jet_flavor" Label="jet_flavor" Title="jet_flavor" Unit="" Internal="jet_flavor" Type="F" Min="0.00000000e+00" Max="2.10000000e+01"/>
+    <Spectator SpecIndex="3" Expression="met_et" Label="met_et" Title="met_et" Unit="" Internal="met_et" Type="F" Min="1.00000010e+01" Max="5.47714386e+01"/>
+  </Spectators>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="4">
+          <Input Type="Variable" Label="jet_k1_pt" Expression="jet_k1_pt"/>
+          <Input Type="Variable" Label="jet_k1_sIP3D" Expression="jet_k1_sIP3D"/>
+          <Input Type="Variable" Label="jet_k2_pt" Expression="jet_k2_pt"/>
+          <Input Type="Variable" Label="jet_k2_sIP3D" Expression="jet_k2_sIP3D"/>
+        </Input>
+        <Output NOutputs="4">
+          <Output Type="Variable" Label="jet_k1_pt" Expression="jet_k1_pt"/>
+          <Output Type="Variable" Label="jet_k1_sIP3D" Expression="jet_k1_sIP3D"/>
+          <Output Type="Variable" Label="jet_k2_pt" Expression="jet_k2_pt"/>
+          <Output Type="Variable" Label="jet_k2_sIP3D" Expression="jet_k2_sIP3D"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="2.4055099487304688e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.2265203094482422e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="1.6399021148681641e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4590104675292969e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.3444671630859375e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4868821716308594e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="3.0755640029907227e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.3749807739257812e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.3444671630859375e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4868821716308594e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="3.0755640029907227e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4590104675292969e+02"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="5">
+        <Neuron NSynapses="16">
+          1.2730848281481419e-01 2.0425429307618748e+00 6.1651373992930891e-01 3.2105167141218099e-01 -7.9323735205943429e+00 -1.3243534037939027e+00 2.7275840492447812e-01 2.0657301080939989e+00 -8.5026327447965866e-01 -4.5743468125284297e+00 -2.6313946368020528e-02 -3.9599766280109960e-01 -1.0878449253336513e+00 -1.6831636026880081e+00 3.5172650868287209e-01 8.3175801843840369e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -3.3251655890740328e+00 1.7056687847935861e+00 3.7777236598921299e-01 3.7670051363194923e+00 -4.6350497357828002e-01 -6.9659297816231636e-01 3.3376265462724952e+01 1.6834946162779751e+00 -1.0962384975198980e+00 6.7208538158822217e-01 5.1129154232548988e+00 -2.8311676288541956e+00 -2.7401934761091229e+00 1.9230787309271978e+01 1.2659504510067961e+01 1.3796999573337005e+00 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -1.5989293296201891e-02 6.5060293668437616e-02 6.3746383898808567e-01 -1.6520768110374426e+00 -2.2219182464321041e+00 1.8157794466679797e+00 -2.7082864168865051e-01 3.6868129963298113e-01 2.2000636900196282e+00 3.1964177550638380e+00 2.3979710067969537e-01 1.0773245989123978e+00 -4.9246983942877148e-01 5.8839141006683693e-02 3.2557039338462247e-02 6.7652112718205903e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          4.0014715878237936e+00 1.3395335166757831e+00 1.7951974694962736e+00 9.5856575925299161e+00 3.2839311825167200e-01 1.7646298699968728e+00 2.1391120015296434e-02 -1.6699669541534976e+00 -1.1960375390046483e-01 -1.5933850404584551e+00 1.3858792086322863e+01 2.2900539490280551e+00 -8.6385211822147157e-01 1.1152647802397574e-01 -3.3167842255581621e-03 5.6528996486488059e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -7.2749072665956482e-02 -4.5849117053084432e-01 -1.8476506164034678e-01 -3.6148214194463120e+00 -8.4898984711066170e+00 -1.0175171762867663e+00 -4.9417513258297499e+00 -7.1878017895859503e-01 1.3395811977174985e-01 -1.9225793101536879e+00 -2.8275451203568545e+00 -2.4271240602295563e-01 -2.4693661319394549e+00 -4.7336699780785390e+00 -6.6964044165655989e-01 -4.1591417009334813e-01 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="17">
+        <Neuron NSynapses="1">
+          1.8527874472246453e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          4.4632883355844144e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.3259737768689908e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.6363326281081214e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.7099438130028417e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.1534635442800456e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.5009381711196612e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.4432041068208479e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.0052446629832876e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.4202258435614139e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          5.3702329551164976e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.2564113204539971e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.0682772557868641e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.2496940049541720e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -5.0216728794061121e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.4697620888336413e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          1.7787955597646703e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/SimpleAnalysis/mva_taggers/TMVAClassification_CharmMuTagger.weights.xml
+++ b/SimpleAnalysis/mva_taggers/TMVAClassification_CharmMuTagger.weights.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0"?>
+<MethodSetup Method="MLP::CharmMuTagger">
+  <GeneralInfo>
+    <Info name="TMVA Release" value="4.2.1 [262657]"/>
+    <Info name="ROOT Release" value="6.18/04 [397828]"/>
+    <Info name="Creator" value="ssekula"/>
+    <Info name="Date" value="Wed Sep 16 14:54:23 2020"/>
+    <Info name="Host" value="Linux lcgapp-centos7-x86-64-32.cern.ch 3.10.0-957.21.3.el7.x86_64 #1 SMP Tue Jun 18 16:35:19 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux"/>
+    <Info name="Dir" value="/scratch/users/ssekula/EIC/delphes_EIC/SimpleAnalysis/scripts"/>
+    <Info name="Training events" value="110000"/>
+    <Info name="TrainingTime" value="6.31361182e+02"/>
+    <Info name="AnalysisType" value="Classification"/>
+  </GeneralInfo>
+  <Options>
+    <Option name="NCycles" modified="Yes">1000</Option>
+    <Option name="HiddenLayers" modified="Yes">N+12</Option>
+    <Option name="NeuronType" modified="Yes">ReLU</Option>
+    <Option name="RandomSeed" modified="No">1</Option>
+    <Option name="EstimatorType" modified="No">CE</Option>
+    <Option name="NeuronInputType" modified="No">sum</Option>
+    <Option name="V" modified="Yes">False</Option>
+    <Option name="VerbosityLevel" modified="No">Default</Option>
+    <Option name="VarTransform" modified="Yes">Norm</Option>
+    <Option name="H" modified="Yes">False</Option>
+    <Option name="CreateMVAPdfs" modified="No">False</Option>
+    <Option name="IgnoreNegWeightsInTraining" modified="No">False</Option>
+    <Option name="TrainingMethod" modified="No">BP</Option>
+    <Option name="LearningRate" modified="No">2.000000e-02</Option>
+    <Option name="DecayRate" modified="No">1.000000e-02</Option>
+    <Option name="TestRate" modified="Yes">5</Option>
+    <Option name="EpochMonitoring" modified="No">False</Option>
+    <Option name="Sampling" modified="No">1.000000e+00</Option>
+    <Option name="SamplingEpoch" modified="No">1.000000e+00</Option>
+    <Option name="SamplingImportance" modified="No">1.000000e+00</Option>
+    <Option name="SamplingTraining" modified="No">True</Option>
+    <Option name="SamplingTesting" modified="No">False</Option>
+    <Option name="ResetStep" modified="No">50</Option>
+    <Option name="Tau" modified="No">3.000000e+00</Option>
+    <Option name="BPMode" modified="No">sequential</Option>
+    <Option name="BatchSize" modified="No">-1</Option>
+    <Option name="ConvergenceImprove" modified="No">1.000000e-30</Option>
+    <Option name="ConvergenceTests" modified="No">-1</Option>
+    <Option name="UseRegulator" modified="Yes">False</Option>
+    <Option name="UpdateLimit" modified="No">10000</Option>
+    <Option name="CalculateErrors" modified="No">False</Option>
+    <Option name="WeightRange" modified="No">1.000000e+00</Option>
+  </Options>
+  <Variables NVar="4">
+    <Variable VarIndex="0" Expression="jet_mu1_pt" Label="jet_mu1_pt" Title="jet_mu1_pt" Unit="" Internal="jet_mu1_pt" Type="F" Min="-1.00000000e+00" Max="3.53291245e+01"/>
+    <Variable VarIndex="1" Expression="jet_mu1_sIP3D" Label="jet_mu1_sIP3D" Title="jet_mu1_sIP3D" Unit="" Internal="jet_mu1_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.48747208e+02"/>
+    <Variable VarIndex="2" Expression="jet_mu2_pt" Label="jet_mu2_pt" Title="jet_mu2_pt" Unit="" Internal="jet_mu2_pt" Type="F" Min="-1.00000000e+00" Max="2.07897243e+01"/>
+    <Variable VarIndex="3" Expression="jet_mu2_sIP3D" Label="jet_mu2_sIP3D" Title="jet_mu2_sIP3D" Unit="" Internal="jet_mu2_sIP3D" Type="F" Min="-1.99000000e+02" Max="1.44923340e+02"/>
+  </Variables>
+  <Spectators NSpec="4">
+    <Spectator SpecIndex="0" Expression="jet_pt" Label="jet_pt" Title="jet_pt" Unit="" Internal="jet_pt" Type="F" Min="5.00084496e+00" Max="5.47973328e+01"/>
+    <Spectator SpecIndex="1" Expression="jet_eta" Label="jet_eta" Title="jet_eta" Unit="" Internal="jet_eta" Type="F" Min="-1.20925403e+00" Max="2.99968314e+00"/>
+    <Spectator SpecIndex="2" Expression="jet_flavor" Label="jet_flavor" Title="jet_flavor" Unit="" Internal="jet_flavor" Type="F" Min="0.00000000e+00" Max="2.10000000e+01"/>
+    <Spectator SpecIndex="3" Expression="met_et" Label="met_et" Title="met_et" Unit="" Internal="met_et" Type="F" Min="1.00000010e+01" Max="5.47714386e+01"/>
+  </Spectators>
+  <Classes NClass="2">
+    <Class Name="Signal" Index="0"/>
+    <Class Name="Background" Index="1"/>
+  </Classes>
+  <Transformations NTransformations="1">
+    <Transform Name="Normalize">
+      <Selection>
+        <Input NInputs="4">
+          <Input Type="Variable" Label="jet_mu1_pt" Expression="jet_mu1_pt"/>
+          <Input Type="Variable" Label="jet_mu1_sIP3D" Expression="jet_mu1_sIP3D"/>
+          <Input Type="Variable" Label="jet_mu2_pt" Expression="jet_mu2_pt"/>
+          <Input Type="Variable" Label="jet_mu2_sIP3D" Expression="jet_mu2_sIP3D"/>
+        </Input>
+        <Output NOutputs="4">
+          <Output Type="Variable" Label="jet_mu1_pt" Expression="jet_mu1_pt"/>
+          <Output Type="Variable" Label="jet_mu1_sIP3D" Expression="jet_mu1_sIP3D"/>
+          <Output Type="Variable" Label="jet_mu2_pt" Expression="jet_mu2_pt"/>
+          <Output Type="Variable" Label="jet_mu2_sIP3D" Expression="jet_mu2_sIP3D"/>
+        </Output>
+      </Selection>
+      <Class ClassIndex="0">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="1.4179519653320312e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4874720764160156e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="1.2594927787780762e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.3971786499023438e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="1">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.5329124450683594e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4867317199707031e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="2.0789724349975586e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4492333984375000e+02"/>
+        </Ranges>
+      </Class>
+      <Class ClassIndex="2">
+        <Ranges>
+          <Range Index="0" Min="-1.0000000000000000e+00" Max="3.5329124450683594e+01"/>
+          <Range Index="1" Min="-1.9900000000000000e+02" Max="1.4874720764160156e+02"/>
+          <Range Index="2" Min="-1.0000000000000000e+00" Max="2.0789724349975586e+01"/>
+          <Range Index="3" Min="-1.9900000000000000e+02" Max="1.4492333984375000e+02"/>
+        </Ranges>
+      </Class>
+    </Transform>
+  </Transformations>
+  <MVAPdfs/>
+  <Weights>
+    <Layout NLayers="3">
+      <Layer Index="0" NNeurons="5">
+        <Neuron NSynapses="16">
+          -6.8997021605723940e-01 1.9079967136836384e+00 -2.4946065513579918e-01 3.0118777121352953e+00 -1.2684856730144629e+00 -1.0564143877531720e+00 -3.9602164215903346e-01 2.0596310152443400e+00 -4.3242417930891913e-01 -2.3894525702749950e-01 4.2764639411632437e-02 -4.5585361531873791e-01 -6.7549046764094889e-01 -2.6556088521521953e-01 4.7947876066121477e-02 4.0150530515529803e-01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -9.8382764700764569e-01 1.6510615019833326e+00 1.1216637269360118e-03 1.2412435561403163e+00 3.0606565451048695e-01 -1.6381889220333712e-01 1.5362764753474693e+01 1.0689901738794857e-01 -8.2102925874277521e-01 2.2401568372176942e-02 1.3192080136013573e+00 -1.1477146190042475e+00 -9.2297907694718295e-01 1.0285263220733937e-01 2.5977478062927957e+00 2.0056328026052640e+01 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -1.1922345852868876e-01 1.7719124964593627e-01 -3.8171775548452642e-02 -1.5331507079487274e+00 -1.0677539440903298e-01 6.1985079923100694e-01 -3.7914899214865655e-01 1.0500879883063681e+00 2.0601943137318863e+00 2.5387118279355239e+00 2.3222409955155352e+00 1.1659474919914794e+00 -2.0188245884983972e-02 -1.4721244135035176e+00 6.3488644559955162e-02 -1.6248143228489838e-02 
+        </Neuron>
+        <Neuron NSynapses="16">
+          1.1298704274289821e+00 1.4041660904374256e+00 5.8560295816070367e+00 -4.4709568697327035e-02 8.6545538820093165e-02 4.8474831356319976e+00 5.4269933905521671e-02 -9.7126904416403692e-01 -7.9370053420547981e-01 -1.8022716041053479e+00 1.8640935981097797e+00 6.7983238390227907e-01 -9.7626562721629673e-01 4.7789841138063183e-01 -2.3146091183624477e-02 -2.5041282773163913e-02 
+        </Neuron>
+        <Neuron NSynapses="16">
+          -6.6318983259173137e-01 -8.0361488644857659e-01 -1.1229750920532231e+00 5.6859533352472169e-01 -9.8265012609695390e-01 -1.8433021542364447e+00 -3.4270185302503511e+00 -1.3680505146501309e+00 1.3040300500454696e-02 5.1989625307319598e-01 9.9785684622871218e-01 -2.9985626436523150e-01 -2.5949234176894160e+00 -2.0252917731014279e+00 -3.1509978953860601e-01 -2.7595980276602337e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="1" NNeurons="17">
+        <Neuron NSynapses="1">
+          5.1242436542891800e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          3.8834470159173995e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          3.0464818318818705e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.7338356578620082e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          2.1007125821137598e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -4.2518412349163279e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -9.1528472388975359e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.1395974561426374e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          7.1812830007992490e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.8408010963050347e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -5.6047118796572071e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -3.1217844934587308e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -8.5363576831626056e-13 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -1.6060622961276738e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.3544293399835639e-01 
+        </Neuron>
+        <Neuron NSynapses="1">
+          6.7702115488861541e+00 
+        </Neuron>
+        <Neuron NSynapses="1">
+          -2.4039153261470765e+00 
+        </Neuron>
+      </Layer>
+      <Layer Index="2" NNeurons="1">
+        <Neuron NSynapses="0"/>
+      </Layer>
+    </Layout>
+  </Weights>
+</MethodSetup>

--- a/SimpleAnalysis/scripts/CharmJetClassification.C
+++ b/SimpleAnalysis/scripts/CharmJetClassification.C
@@ -31,87 +31,165 @@ void CharmJetClassification(TString dir, TString input, TString filePattern = "*
   gStyle->SetOptStat(0);
 
   // Create the TCanvas
-  TCanvas* pad = new TCanvas("pad","",800,600);
-  TLegend * legend = nullptr;
-  TH1F* htemplate = nullptr;
+  TCanvas *pad = new TCanvas("pad",
+                             "",
+                             800,
+                             600);
+  TLegend *legend    = nullptr;
+  TH1F    *htemplate = nullptr;
 
   auto default_data = new TChain("tree");
   default_data->SetTitle(input.Data());
   auto files = fileVector(Form("%s/%s/%s", dir.Data(), input.Data(), filePattern.Data()));
 
   for (auto file : files)
-    {
-      default_data->Add(file.c_str());
-    }
+  {
+    default_data->Add(file.c_str());
+  }
 
   // Create the signal and background trees
 
-  auto signal_train = default_data->CopyTree("jet_flavor==4 && jet_n>0", "", TMath::Floor(default_data->GetEntries()/1.0));
+  auto signal_train = default_data->CopyTree("jet_flavor==4 && jet_n>0", "", TMath::Floor(default_data->GetEntries() / 1.0));
   std::cout << "Signal Tree (Training): " << signal_train->GetEntries() << std::endl;
 
-  auto background_train = default_data->CopyTree("(jet_flavor<4||jet_flavor==21) && jet_n>0", "", TMath::Floor(default_data->GetEntries()/1.0));
+  auto background_train = default_data->CopyTree("(jet_flavor<4||jet_flavor==21) && jet_n>0", "", TMath::Floor(default_data->GetEntries() / 1.0));
   std::cout << "Background Tree (Training): " << background_train->GetEntries() << std::endl;
 
-  // auto u_background_train = default_data->CopyTree("(jet_flavor==2)", "", TMath::Floor(default_data->GetEntries()/1.0));
-  // std::cout << "u Background Tree (Training): " << u_background_train->GetEntries() << std::endl;
+  // auto u_background_train = default_data->CopyTree("(jet_flavor==2)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "u Background Tree (Training): " <<
+  // u_background_train->GetEntries() << std::endl;
 
-  // auto d_background_train = default_data->CopyTree("(jet_flavor==1)", "", TMath::Floor(default_data->GetEntries()/1.0));
-  // std::cout << "d Background Tree (Training): " << d_background_train->GetEntries() << std::endl;
+  // auto d_background_train = default_data->CopyTree("(jet_flavor==1)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "d Background Tree (Training): " <<
+  // d_background_train->GetEntries() << std::endl;
 
-  // auto g_background_train = default_data->CopyTree("(jet_flavor==21)", "", TMath::Floor(default_data->GetEntries()/1.0));
-  // std::cout << "g Background Tree (Training): " << g_background_train->GetEntries() << std::endl;
+  // auto g_background_train = default_data->CopyTree("(jet_flavor==21)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "g Background Tree (Training): " <<
+  // g_background_train->GetEntries() << std::endl;
 
   // Create the TMVA tools
   TMVA::Tools::Instance();
 
   auto outputFile = TFile::Open("CharmJetClassification_Results.root", "RECREATE");
 
-  TMVA::Factory factory("TMVAClassification", outputFile,
-			"!V:ROC:!Correlations:!Silent:Color:DrawProgressBar:AnalysisType=Classification" );
+  TMVA::Factory factory("TMVAClassification",
+                        outputFile,
+                        "!V:ROC:!Correlations:!Silent:Color:DrawProgressBar:AnalysisType=Classification");
+
+  //
+  // Kaon Tagger
+  //
+
+  TMVA::DataLoader loader_ktagger("dataset_ktagger");
+  TMVA::DataLoader loader_etagger("dataset_etagger");
+  TMVA::DataLoader loader_mutagger("dataset_mutagger");
+  TMVA::DataLoader loader_ip3dtagger("dataset_ip3dtagger");
+
+  // loader_ktagger.AddVariable("jet_pt",  "Jet p_{T}",          "GeV", 'F',
+  // 0.0,
+  // 1000.0);
+  // loader_ktagger.AddVariable("jet_eta", "Jet Pseudorapidity", "",    'F',
+  // -5.0, 5.0);
+
+  loader_ktagger.AddSpectator("jet_pt");
+  loader_ktagger.AddSpectator("jet_eta");
+  loader_ktagger.AddVariable("jet_k1_pt");
+  loader_ktagger.AddVariable("jet_k1_sIP3D");
+  loader_ktagger.AddVariable("jet_k2_pt");
+  loader_ktagger.AddVariable("jet_k2_sIP3D");
+  loader_ktagger.AddSpectator("jet_flavor");
+  loader_ktagger.AddSpectator("met_et");
+  loader_ktagger.AddSignalTree(signal_train, 1.0);
+  loader_ktagger.AddBackgroundTree(background_train, 1.0);
+
+  // loader_ktagger.AddVariable("jet_nconstituents");
+
+  loader_etagger.AddSpectator("jet_pt");
+  loader_etagger.AddSpectator("jet_eta");
+  loader_etagger.AddVariable("jet_e1_pt");
+  loader_etagger.AddVariable("jet_e1_sIP3D");
+  loader_etagger.AddVariable("jet_e2_pt");
+  loader_etagger.AddVariable("jet_e2_sIP3D");
+  loader_etagger.AddSpectator("jet_flavor");
+  loader_etagger.AddSpectator("met_et");
+  loader_etagger.AddSignalTree(signal_train, 1.0);
+  loader_etagger.AddBackgroundTree(background_train, 1.0);
+
+  loader_mutagger.AddSpectator("jet_pt");
+  loader_mutagger.AddSpectator("jet_eta");
+  loader_mutagger.AddVariable("jet_mu1_pt");
+  loader_mutagger.AddVariable("jet_mu1_sIP3D");
+  loader_mutagger.AddVariable("jet_mu2_pt");
+  loader_mutagger.AddVariable("jet_mu2_sIP3D");
+  loader_mutagger.AddSpectator("jet_flavor");
+  loader_mutagger.AddSpectator("met_et");
+  loader_mutagger.AddSignalTree(signal_train, 1.0);
+  loader_mutagger.AddBackgroundTree(background_train, 1.0);
 
 
-  TMVA::DataLoader loader("dataset");
+  loader_ip3dtagger.AddSpectator("jet_pt");
+  loader_ip3dtagger.AddSpectator("jet_eta");
+  loader_ip3dtagger.AddVariable("jet_t1_pt");
+  loader_ip3dtagger.AddVariable("jet_t1_sIP3D");
+  loader_ip3dtagger.AddVariable("jet_t2_pt");
+  loader_ip3dtagger.AddVariable("jet_t2_sIP3D");
+  loader_ip3dtagger.AddVariable("jet_t3_pt");
+  loader_ip3dtagger.AddVariable("jet_t3_sIP3D");
+  loader_ip3dtagger.AddVariable("jet_t4_pt");
+  loader_ip3dtagger.AddVariable("jet_t4_sIP3D");
+  loader_ip3dtagger.AddSpectator("jet_flavor");
+  loader_ip3dtagger.AddSpectator("met_et");
+  loader_ip3dtagger.AddSignalTree(signal_train, 1.0);
+  loader_ip3dtagger.AddBackgroundTree(background_train, 1.0);
 
-  loader.AddVariable("jet_pt", "Jet p_{T}", "GeV", 'F', 0.0, 1000.0);
-  loader.AddVariable("jet_eta", "Jet Pseudorapidity", "", 'F', -5.0, 5.0);
-  // loader.AddSpectator("jet_pt");
-  // loader.AddSpectator("jet_eta");
-
-  //loader.AddVariable("jet_nconstituents");
-  // loader.AddVariable("jet_k1_pt");
-  // loader.AddVariable("jet_k1_sIP3D");
-  // loader.AddVariable("jet_k2_pt");
-  // loader.AddVariable("jet_k2_sIP3D");
-  loader.AddVariable("jet_t1_pt");
-  loader.AddVariable("jet_t1_sIP3D");
-  loader.AddVariable("jet_t2_pt");
-  loader.AddVariable("jet_t2_sIP3D");
-  loader.AddVariable("jet_t3_pt");
-  loader.AddVariable("jet_t3_sIP3D");
-  loader.AddVariable("jet_t4_pt");
-  loader.AddVariable("jet_t4_sIP3D");
-  //  loader.AddVariable("jet_sip3dtag", "sIP3D Jet-Level Tag", "", 'B', -10, 10);
+  //  loader.AddVariable("jet_sip3dtag", "sIP3D Jet-Level Tag", "", 'B', -10,
+  // 10);
   // loader.AddVariable("jet_charge");
-  // loader.AddVariable("jet_ehadoveremratio");
-  loader.AddSpectator("jet_flavor");
-  loader.AddSpectator("met_et");
 
-  loader.AddSignalTree( signal_train, 1.0 );
-  loader.AddBackgroundTree( background_train, 1.0 );
+  // loader.AddVariable("jet_ehadoveremratio");
+
+
   // loader.AddTree( signal_train, "strange_jets" );
   // loader.AddTree( u_background_train, "up jets" );
   // loader.AddTree( d_background_train, "down jets" );
   // loader.AddTree( g_background_train, "gluon jets" );
 
-  loader.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
-				    TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
-   				    "nTrain_Signal=10000:nTrain_Background=100000:nTest_Signal=10000:nTest_Background=100000:SplitMode=Random:NormMode=NumEvents:!V" );
+  loader_ktagger.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+                                            TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+                                            "nTrain_Signal=50000:nTrain_Background=500000:nTest_Signal=50000:nTest_Background=500000:SplitMode=Random:NormMode=NumEvents:!V");
+  loader_etagger.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+                                            TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+                                            "nTrain_Signal=100000:nTrain_Background=1000000:nTest_Signal=100000:nTest_Background=1000000:SplitMode=Random:NormMode=NumEvents:!V");
+  loader_mutagger.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+                                             TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+                                             "nTrain_Signal=100000:nTrain_Background=1000000:nTest_Signal=100000:nTest_Background=1000000:SplitMode=Random:NormMode=NumEvents:!V");
+  loader_ip3dtagger.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+                                               TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+                                               "nTrain_Signal=10000:nTrain_Background=100000:nTest_Signal=10000:nTest_Background=100000:SplitMode=Random:NormMode=NumEvents:!V");
 
   // Declare the classification method(s)
   // factory.BookMethod(&loader,TMVA::Types::kBDT, "BDT",
-  // 		     "!V:NTrees=1000:MinNodeSize=2.5%:MaxDepth=4:BoostType=AdaBoost:AdaBoostBeta=0.5:UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20" );
-  factory.BookMethod(&loader,TMVA::Types::kMLP, "MLP",
-		     "!H:!V:NeuronType=tanh:VarTransform=N:NCycles=600:HiddenLayers=N+5:TestRate=5:!UseRegulator" );
+  //
+  //
+  //  "!V:NTrees=1000:MinNodeSize=2.5%:MaxDepth=4:BoostType=AdaBoost:AdaBoostBeta=0.5:UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20"
+  // );
+  factory.BookMethod(&loader_ktagger,    TMVA::Types::kMLP, "CharmKTagger",
+                     "!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=1000:HiddenLayers=N+12:TestRate=5:!UseRegulator");
+  factory.BookMethod(&loader_etagger,    TMVA::Types::kMLP, "CharmETagger",
+                     "!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=1000:HiddenLayers=N+12:TestRate=5:!UseRegulator");
+  factory.BookMethod(&loader_mutagger,   TMVA::Types::kMLP, "CharmMuTagger",
+                     "!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=1000:HiddenLayers=N+12:TestRate=5:!UseRegulator");
+  factory.BookMethod(&loader_ip3dtagger, TMVA::Types::kMLP, "CharmIP3DTagger",
+                     "!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=1000:HiddenLayers=N+16:TestRate=5:!UseRegulator");
+
+  // factory.BookMethod(&loader, TMVA::Types::kMLP,
+  // "CharmETagger","!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=600:HiddenLayers=N+8:TestRate=5:!UseRegulator");
+  // factory.BookMethod(&loader, TMVA::Types::kMLP,
+  // "CharmMuTagger","!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=600:HiddenLayers=N+8:TestRate=5:!UseRegulator");
+
   // Train
   factory.TrainAllMethods();
 
@@ -121,9 +199,11 @@ void CharmJetClassification(TString dir, TString input, TString filePattern = "*
 
   // Plot a ROC Curve
   pad->cd();
-  pad = factory.GetROCCurve(&loader);
+  pad = factory.GetROCCurve(&loader_ktagger);
+  pad = factory.GetROCCurve(&loader_etagger);
+  pad = factory.GetROCCurve(&loader_mutagger);
+  pad = factory.GetROCCurve(&loader_ip3dtagger);
   pad->Draw();
 
   pad->SaveAs("CharmJetClassification_ROC.pdf");
-
 }

--- a/SimpleAnalysis/scripts/CharmJetClassification.C
+++ b/SimpleAnalysis/scripts/CharmJetClassification.C
@@ -1,0 +1,129 @@
+#include "TROOT.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TEfficiency.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+#include "TCut.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TRatioPlot.h"
+
+#include "TMVA/Factory.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/Tools.h"
+
+#include <glob.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+#include "PlotFunctions.h"
+
+
+void CharmJetClassification(TString dir, TString input, TString filePattern = "*/out.root")
+{
+  // Global options
+  gStyle->SetOptStat(0);
+
+  // Create the TCanvas
+  TCanvas* pad = new TCanvas("pad","",800,600);
+  TLegend * legend = nullptr;
+  TH1F* htemplate = nullptr;
+
+  auto default_data = new TChain("tree");
+  default_data->SetTitle(input.Data());
+  auto files = fileVector(Form("%s/%s/%s", dir.Data(), input.Data(), filePattern.Data()));
+
+  for (auto file : files)
+    {
+      default_data->Add(file.c_str());
+    }
+
+  // Create the signal and background trees
+
+  auto signal_train = default_data->CopyTree("jet_flavor==4 && jet_n>0", "", TMath::Floor(default_data->GetEntries()/1.0));
+  std::cout << "Signal Tree (Training): " << signal_train->GetEntries() << std::endl;
+
+  auto background_train = default_data->CopyTree("(jet_flavor<4||jet_flavor==21) && jet_n>0", "", TMath::Floor(default_data->GetEntries()/1.0));
+  std::cout << "Background Tree (Training): " << background_train->GetEntries() << std::endl;
+
+  // auto u_background_train = default_data->CopyTree("(jet_flavor==2)", "", TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "u Background Tree (Training): " << u_background_train->GetEntries() << std::endl;
+
+  // auto d_background_train = default_data->CopyTree("(jet_flavor==1)", "", TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "d Background Tree (Training): " << d_background_train->GetEntries() << std::endl;
+
+  // auto g_background_train = default_data->CopyTree("(jet_flavor==21)", "", TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "g Background Tree (Training): " << g_background_train->GetEntries() << std::endl;
+
+  // Create the TMVA tools
+  TMVA::Tools::Instance();
+
+  auto outputFile = TFile::Open("CharmJetClassification_Results.root", "RECREATE");
+
+  TMVA::Factory factory("TMVAClassification", outputFile,
+			"!V:ROC:!Correlations:!Silent:Color:DrawProgressBar:AnalysisType=Classification" );
+
+
+  TMVA::DataLoader loader("dataset");
+
+  loader.AddVariable("jet_pt", "Jet p_{T}", "GeV", 'F', 0.0, 1000.0);
+  loader.AddVariable("jet_eta", "Jet Pseudorapidity", "", 'F', -5.0, 5.0);
+  // loader.AddSpectator("jet_pt");
+  // loader.AddSpectator("jet_eta");
+
+  //loader.AddVariable("jet_nconstituents");
+  // loader.AddVariable("jet_k1_pt");
+  // loader.AddVariable("jet_k1_sIP3D");
+  // loader.AddVariable("jet_k2_pt");
+  // loader.AddVariable("jet_k2_sIP3D");
+  loader.AddVariable("jet_t1_pt");
+  loader.AddVariable("jet_t1_sIP3D");
+  loader.AddVariable("jet_t2_pt");
+  loader.AddVariable("jet_t2_sIP3D");
+  loader.AddVariable("jet_t3_pt");
+  loader.AddVariable("jet_t3_sIP3D");
+  loader.AddVariable("jet_t4_pt");
+  loader.AddVariable("jet_t4_sIP3D");
+  //  loader.AddVariable("jet_sip3dtag", "sIP3D Jet-Level Tag", "", 'B', -10, 10);
+  // loader.AddVariable("jet_charge");
+  // loader.AddVariable("jet_ehadoveremratio");
+  loader.AddSpectator("jet_flavor");
+  loader.AddSpectator("met_et");
+
+  loader.AddSignalTree( signal_train, 1.0 );
+  loader.AddBackgroundTree( background_train, 1.0 );
+  // loader.AddTree( signal_train, "strange_jets" );
+  // loader.AddTree( u_background_train, "up jets" );
+  // loader.AddTree( d_background_train, "down jets" );
+  // loader.AddTree( g_background_train, "gluon jets" );
+
+  loader.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+				    TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+   				    "nTrain_Signal=10000:nTrain_Background=100000:nTest_Signal=10000:nTest_Background=100000:SplitMode=Random:NormMode=NumEvents:!V" );
+
+  // Declare the classification method(s)
+  // factory.BookMethod(&loader,TMVA::Types::kBDT, "BDT",
+  // 		     "!V:NTrees=1000:MinNodeSize=2.5%:MaxDepth=4:BoostType=AdaBoost:AdaBoostBeta=0.5:UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20" );
+  factory.BookMethod(&loader,TMVA::Types::kMLP, "MLP",
+		     "!H:!V:NeuronType=tanh:VarTransform=N:NCycles=600:HiddenLayers=N+5:TestRate=5:!UseRegulator" );
+  // Train
+  factory.TrainAllMethods();
+
+  // Test
+  factory.TestAllMethods();
+  factory.EvaluateAllMethods();
+
+  // Plot a ROC Curve
+  pad->cd();
+  pad = factory.GetROCCurve(&loader);
+  pad->Draw();
+
+  pad->SaveAs("CharmJetClassification_ROC.pdf");
+
+}

--- a/SimpleAnalysis/scripts/CharmJetClassification_Plots.C
+++ b/SimpleAnalysis/scripts/CharmJetClassification_Plots.C
@@ -1,0 +1,153 @@
+#include "TROOT.h"
+#include "TChain.h"
+#include "TEfficiency.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+#include "TCut.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TRatioPlot.h"
+
+#include <glob.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+#include "PlotFunctions.h"
+
+
+float target_xsec = LookupCrossSection("CC_DIS");
+
+float target_lumi = 100 * u_fb;
+
+float n_gen = -1;
+
+
+void CharmJetClassification_Plots()
+{
+  // Global options
+  gStyle->SetOptStat(0);
+
+  // Create the TCanvas
+  TCanvas *pad       = new TCanvas("pad", "", 800, 600);
+  TLegend *legend    = nullptr;
+  TH1F    *htemplate = nullptr;
+
+  std::vector<TString> input_folders = { "dataset_ip3dtagger", "dataset_ktagger", "dataset_etagger", "dataset_mutagger" };
+  std::vector<TString> input_vars    = { "jet_t1_pt", "jet_t1_sIP3D", "jet_t2_pt", "jet_t2_sIP3D", "jet_t3_pt", "jet_t3_sIP3D", "jet_t4_pt", "jet_t4_sIP3D", "jet_k1_pt", "jet_k1_sIP3D", "jet_k2_pt", "jet_k2_sIP3D", "jet_e1_pt", "jet_e1_sIP3D", "jet_e2_pt", "jet_e2_sIP3D", "jet_mu1_pt", "jet_mu1_sIP3D", "jet_mu2_pt", "jet_mu2_sIP3D" };
+
+  for (auto input_folder : input_folders) {
+    std::cout << input_folder.Data() << std::endl;
+
+    for (auto input_var : input_vars) {
+      std::cout << input_var.Data() << std::endl;
+
+      TChain testing_data(Form("%s/TestTree", input_folder.Data()));
+      TChain training_data(Form("%s/TrainTree", input_folder.Data()));
+
+      testing_data.Add("CharmJetClassification_Results.root");
+      training_data.Add("CharmJetClassification_Results.root");
+
+      pad->Clear();
+
+      // pad->Divide(1,2);
+      pad->cd();
+
+      TH1F *h_signal     = nullptr;
+      TH1F *h_background = nullptr;
+
+      if (input_var.Contains("pt") == kTRUE) {
+        h_signal = new TH1F("h_signal", "signal distribution", 100, 0, 15);
+        h_signal->Sumw2();
+        pad->SetLogy(kFALSE);
+      }
+
+      if (input_var.Contains("sIP3D") == kTRUE) {
+        h_signal = new TH1F("h_signal", "signal distribution", 200, -100, 100);
+        h_signal->Sumw2();
+        pad->SetLogy();
+      }
+
+      if (h_signal == nullptr) {
+        continue;
+      }
+
+      h_background = static_cast<TH1F *>(h_signal->Clone("h_background"));
+      training_data.Project(h_signal->GetName(),     input_var.Data(), "jet_flavor==4");
+      training_data.Project(h_background->GetName(), input_var.Data(), "jet_flavor<4 || jet_flavor==22");
+
+      if ((h_signal->GetEntries() == 0) || (h_background->GetEntries() == 0)) {
+        if (h_signal) {
+          delete h_signal;
+        }
+
+        if (h_background) {
+          delete h_background;
+        }
+        continue;
+      }
+
+      auto h_signal_norm     = h_signal->DrawNormalized("HIST");
+      auto h_background_norm = h_background->DrawNormalized("HIST SAME");
+
+      h_signal_norm->SetLineWidth(2);
+      h_signal_norm->SetLineColor(kBlue);
+
+      h_background_norm->SetLineWidth(2);
+      h_background_norm->SetLineColor(kRed);
+      h_background_norm->SetLineStyle(kDashed);
+
+      Float_t max_value = TMath::Max(h_signal_norm->GetMaximum(), h_background_norm->GetMaximum());
+
+      Float_t min_value = 0.0;
+
+      if (input_var.Contains("sIP3D") == kTRUE) {
+        min_value = 1e-6;
+      }
+
+      h_signal_norm->SetMaximum(max_value * 1.25);
+      h_background_norm->SetMaximum(max_value * 1.25);
+      h_signal_norm->SetMinimum(min_value);
+      h_background_norm->SetMinimum(min_value);
+
+      // Label axes
+      h_signal_norm->SetYTitle("Probability");
+
+      if (input_var.Contains("sIP3D") == kTRUE) {
+        h_signal_norm->SetXTitle("Track sIP_{3D}");
+      }
+
+      if (input_var.Contains("pt") == kTRUE) {
+        h_signal_norm->SetXTitle("Track p_{T}");
+      }
+
+      pad->SetGrid(1, 1);
+
+      // Legend
+      TLegend *legend = smart_legend("upper right");
+      legend->SetFillStyle(0);
+      legend->SetBorderSize(0);
+      legend->AddEntry(h_signal_norm,     "True Charm Jets", "lf");
+      legend->AddEntry(h_background_norm, "True Light Jets", "lp");
+      legend->Draw();
+
+
+      pad->SaveAs(Form("%s.pdf", input_var.Data()));
+
+      if (h_signal) {
+        delete h_signal;
+      }
+
+      if (h_background) {
+        delete h_background;
+      }
+
+      if (legend)
+        delete legend;
+    }
+  }
+}

--- a/SimpleAnalysis/scripts/CharmJetClassifier_Scan.C
+++ b/SimpleAnalysis/scripts/CharmJetClassifier_Scan.C
@@ -1,0 +1,73 @@
+#include "TROOT.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TTreeFormula.h"
+#include <iostream>
+#include "TMath.h"
+#include "TH1.h"
+#include "TCut.h"
+#include <map>
+
+void CharmJetClassifier_Scan(TString inputfile = "CharmJetClassification_Results.root",
+			     TString foldername = "dataset",
+			     TString taggername = "MLP",
+			     Float_t bkg_eff = 0.004) {
+  TFile *_file0    = TFile::Open(inputfile.Data());
+  TTree *TestTree  = static_cast < TTree * > (_file0->Get(Form("%s/TestTree", foldername.Data())));
+  TTree *TrainTree = static_cast < TTree * > (_file0->Get(Form("%s/TrainTree", foldername.Data())));
+
+  Float_t nlight = TestTree->GetEntries("jet_flavor<4 || jet_flavor==22");
+  Float_t ncharm = TestTree->GetEntries("jet_flavor==4");
+
+
+  Float_t opt_cut  = 0.000;
+  Float_t min_dist = 1000.0;
+
+  for (Float_t mva_cut = 0.000; mva_cut < 1.000; mva_cut += 0.001) {
+    Float_t nlight_pass = TestTree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && met_et > 10.0 && (jet_flavor<4 || jet_flavor==22) && %s>%f", taggername.Data(), mva_cut));
+    Float_t ncharm_pass = TestTree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && met_et > 10.0 && (jet_flavor==4) && %s>%f", taggername.Data(), mva_cut));
+
+    Float_t light_eff = nlight_pass / nlight;
+
+    if (TMath::Abs(light_eff - bkg_eff) < min_dist) {
+      min_dist = TMath::Abs(light_eff - bkg_eff);
+      opt_cut  = mva_cut;
+    }
+  }
+
+  // Print the final selection information
+  Float_t nlight_pass = TestTree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && met_et > 10.0 && (jet_flavor<4 || jet_flavor==22) && %s>%f", taggername.Data(), opt_cut));
+  Float_t ncharm_pass = TestTree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && met_et > 10.0 && (jet_flavor==4) && %s>%f", taggername.Data(), opt_cut));
+
+  std::cout << Form("MLP cut %.3f", opt_cut) << " yields Eff_c = "
+            << Form("%.3f", ncharm_pass / ncharm) << " and Eff_light = "
+            << Form("%.3e", nlight_pass / nlight) << std::endl;
+
+
+  /// Use the K-S Test to Compare the Training/Testing Shapes in Signal and
+  // Background.
+  std::cout << "Over-Training Study" << std::endl;
+  std::cout << "=============================================" << std::endl;
+  std::map < TString, TCut > samples;
+  samples["Signal"]     = TCut("jet_flavor==4");
+  samples["Background"] = TCut("(jet_flavor<4 || jet_flavor==22)");
+
+  for (auto sample : samples) {
+    TH1F *h_train = new TH1F("h_train",
+                             "",
+                             100,
+                             0,
+                             1);
+    h_train->Sumw2();
+    auto h_test = static_cast < TH1F * > (h_train->Clone("h_test"));
+
+    TrainTree->Project(h_train->GetName(), Form("%s",taggername.Data()), sample.second);
+    TestTree->Project(h_test->GetName(), Form("%s",taggername.Data()), sample.second);
+    Float_t KS_Test = h_test->KolmogorovTest(h_train);
+    std::cout << sample.first << ": K-S Test p-value = " << KS_Test << std::endl;
+
+    if (h_test) delete h_test;
+
+    if (h_train) delete h_train;
+  }
+}

--- a/SimpleAnalysis/scripts/CharmJetGlobalTagger.C
+++ b/SimpleAnalysis/scripts/CharmJetGlobalTagger.C
@@ -1,0 +1,144 @@
+#include "TROOT.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TEfficiency.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+#include "TCut.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TRatioPlot.h"
+
+#include "TMVA/Factory.h"
+#include "TMVA/DataLoader.h"
+#include "TMVA/Tools.h"
+
+#include <glob.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+#include "PlotFunctions.h"
+
+
+void CharmJetGlobalTagger(TString dir, TString input, TString filePattern = "*/out.root")
+{
+  // Global options
+  gStyle->SetOptStat(0);
+
+  // Create the TCanvas
+  TCanvas *pad = new TCanvas("pad",
+                             "",
+                             800,
+                             600);
+  TLegend *legend    = nullptr;
+  TH1F    *htemplate = nullptr;
+
+  auto default_data = new TChain("tree");
+  default_data->SetTitle(input.Data());
+  auto files = fileVector(Form("%s/%s/%s", dir.Data(), input.Data(), filePattern.Data()));
+
+  for (auto file : files)
+  {
+    default_data->Add(file.c_str());
+  }
+
+  // Create the signal and background trees
+
+  auto signal_train = default_data->CopyTree("jet_flavor==4 && jet_n>0", "", TMath::Floor(default_data->GetEntries() / 1.0));
+  std::cout << "Signal Tree (Training): " << signal_train->GetEntries() << std::endl;
+
+  auto background_train = default_data->CopyTree("(jet_flavor<4||jet_flavor==21) && jet_n>0", "", TMath::Floor(default_data->GetEntries() / 1.0));
+  std::cout << "Background Tree (Training): " << background_train->GetEntries() << std::endl;
+
+  // auto u_background_train = default_data->CopyTree("(jet_flavor==2)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "u Background Tree (Training): " <<
+  // u_background_train->GetEntries() << std::endl;
+
+  // auto d_background_train = default_data->CopyTree("(jet_flavor==1)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "d Background Tree (Training): " <<
+  // d_background_train->GetEntries() << std::endl;
+
+  // auto g_background_train = default_data->CopyTree("(jet_flavor==21)", "",
+  // TMath::Floor(default_data->GetEntries()/1.0));
+  // std::cout << "g Background Tree (Training): " <<
+  // g_background_train->GetEntries() << std::endl;
+
+  // Create the TMVA tools
+  TMVA::Tools::Instance();
+
+  auto outputFile = TFile::Open("CharmJetGlobalTagger_Results.root", "RECREATE");
+
+  TMVA::Factory factory("TMVAClassification",
+                        outputFile,
+                        "!V:ROC:!Correlations:!Silent:Color:DrawProgressBar:AnalysisType=Classification");
+
+  //
+  // Kaon Tagger
+  //
+
+  TMVA::DataLoader loader("dataset");
+
+  // loader.AddVariable("jet_pt",  "Jet p_{T}",          "GeV", 'F',
+  // 0.0,
+  // 1000.0);
+  // loader.AddVariable("jet_eta", "Jet Pseudorapidity", "",    'F',
+  // -5.0, 5.0);
+
+  loader.AddSpectator("jet_pt");
+  loader.AddSpectator("jet_eta");
+  loader.AddSpectator("jet_flavor");
+  loader.AddSpectator("met_et");
+  loader.AddVariable("jet_mlp_ip3dtagger");
+  loader.AddVariable("jet_mlp_ktagger");
+  loader.AddVariable("jet_mlp_eltagger");
+  loader.AddVariable("jet_mlp_mutagger");
+  loader.AddSignalTree(signal_train, 1.0);
+  loader.AddBackgroundTree(background_train, 1.0);
+
+
+  //  loader.AddVariable("jet_sip3dtag", "sIP3D Jet-Level Tag", "", 'B', -10,
+  // 10);
+  // loader.AddVariable("jet_charge");
+
+  // loader.AddVariable("jet_ehadoveremratio");
+
+
+  // loader.AddTree( signal_train, "strange_jets" );
+  // loader.AddTree( u_background_train, "up jets" );
+  // loader.AddTree( d_background_train, "down jets" );
+  // loader.AddTree( g_background_train, "gluon jets" );
+
+  loader.PrepareTrainingAndTestTree(TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor==4 && met_et > 10"),
+				    TCut("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor<4||jet_flavor==21) && met_et > 10"),
+				    "nTrain_Signal=10000:nTrain_Background=100000:nTest_Signal=10000:nTest_Background=100000:SplitMode=Random:NormMode=NumEvents:!V");
+  
+  // Declare the classification method(s)
+  // factory.BookMethod(&loader,TMVA::Types::kBDT, "BDT",
+  //
+  //
+  //  "!V:NTrees=1000:MinNodeSize=2.5%:MaxDepth=4:BoostType=AdaBoost:AdaBoostBeta=0.5:UseBaggedBoost:BaggedSampleFraction=0.5:SeparationType=GiniIndex:nCuts=20"
+  // );
+  factory.BookMethod(&loader,    TMVA::Types::kMLP, "CharmGlobalTagger",
+                     "!H:!V:NeuronType=ReLU:VarTransform=Norm:NCycles=1000:HiddenLayers=N+8:TestRate=5:!UseRegulator");
+
+  // Train
+  factory.TrainAllMethods();
+
+  // Test
+  factory.TestAllMethods();
+  factory.EvaluateAllMethods();
+
+  // Plot a ROC Curve
+  pad->cd();
+  pad = factory.GetROCCurve(&loader);
+  pad->Draw();
+
+  pad->SaveAs("CharmJetGlobalTagger_ROC.pdf");
+}

--- a/SimpleAnalysis/scripts/CharmJetMVAOptimization.C
+++ b/SimpleAnalysis/scripts/CharmJetMVAOptimization.C
@@ -1,0 +1,139 @@
+#include "TROOT.h"
+#include "TChain.h"
+#include "TFile.h"
+#include "TEfficiency.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+#include "TCut.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TRatioPlot.h"
+
+
+#include <glob.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+#include "PlotFunctions.h"
+
+
+void CharmJetMVAOptimization(TString filename = "CharmJetClassification_Results.root",
+			     TString foldername = "dataset",
+			     TString classifiername = "MLP")
+{
+  // Global options
+  gStyle->SetOptStat(0);
+
+
+  // Scan the output for the optimal performance point and quote the results
+  float target_xsec = LookupCrossSection("CC_DIS");
+  float eff_xsec_light = target_xsec * 0.983;
+  float eff_xsec_charm = target_xsec * 0.020;
+  float target_lumi = 100*u_fb;
+
+  auto result_file = TFile::Open(filename.Data());
+  auto result_tree = static_cast<TTree*>(result_file->Get(Form("%s/TestTree", foldername.Data())));
+
+  float max_charm_yield_signifiance = 0.0;
+  float optimal_mva_cut = 0.0;
+	float optimal_charm_efficiency = 0.0;
+  float optimal_light_efficiency = 0.0;
+	float optimal_charm_yield = 0.0;
+  float optimal_light_yield = 0.0;
+
+
+  float n_light_all = static_cast<float>(result_tree->GetEntries("(jet_flavor==21 || jet_flavor < 4)"));
+  float n_charm_all = static_cast<float>(result_tree->GetEntries("(jet_flavor == 4)"));
+
+  float w_light = target_lumi * eff_xsec_light / n_light_all;
+  float w_charm = target_lumi * eff_xsec_charm / n_charm_all;
+
+  TH1F* h_light = new TH1F("h_light","",50,0,1.0);
+  h_light->Sumw2();
+  auto h_charm = static_cast<TH1F*>(h_light->Clone("h_charm"));
+
+  result_tree->Project(h_light->GetName(), classifiername.Data(), "jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor==21 || jet_flavor < 4) && met_et > 10");
+  result_tree->Project(h_charm->GetName(), classifiername.Data(), "jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor==4) && met_et > 10");
+
+
+  Int_t nbins = h_light->GetNbinsX();
+
+  for (Int_t i = 1; i <= h_light->GetNbinsX(); i++) {
+    float min = h_light->GetBinLowEdge(i);
+    std::cout << min << std::endl;
+
+    float n_light = h_light->Integral(i, nbins);
+    float n_charm = h_charm->Integral(i, nbins);
+
+    float eff_light = n_light/n_light_all;
+    float eff_charm = n_charm/n_charm_all;
+
+
+    // Scale the number of light and charm yields to target_lumi
+    n_light = n_light * w_light;
+    n_charm = n_charm * w_charm;
+    float n_total = n_light + n_charm;
+
+    float err_light = TMath::Sqrt(n_light);
+    float err_charm = TMath::Sqrt(n_charm);
+
+
+    float err_yield = TMath::Sqrt(n_total + n_light);
+    float yield_significance = n_charm / err_yield;
+
+    if (yield_significance > max_charm_yield_signifiance) {
+      max_charm_yield_signifiance = yield_significance;
+      optimal_mva_cut = min;
+			optimal_charm_efficiency = eff_charm;
+      optimal_light_efficiency = eff_light;
+			optimal_charm_yield = n_charm;
+      optimal_light_yield = n_light;
+    }
+
+  }
+
+
+  // for (float min = 0.0; min <= 1.0; min += 0.02) {
+  //   std::cout << min << std::endl;
+
+  //   float n_light = static_cast<float>(result_tree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor==21 || jet_flavor < 4) && met_et > 10 && MLP > %.5f", min)));
+  //   float n_charm = static_cast<float>(result_tree->GetEntries(Form("jet_pt>5.0 && TMath::Abs(jet_eta) < 3.0 && (jet_flavor == 4) && met_et > 10 && MLP > %.5f", min)));
+
+
+  //   float eff_light = n_light/n_light_all;
+  //   float eff_charm = n_charm/n_charm_all;
+
+  //   // Scale the number of light and charm yields to target_lumi
+  //   n_light = n_light * w_light;
+  //   n_charm = n_charm * w_charm;
+  //   float n_total = n_light + n_charm;
+
+  //   float err_light = TMath::Sqrt(n_light);
+  //   float err_charm = TMath::Sqrt(n_charm);
+
+
+  //   float err_yield = TMath::Sqrt(n_total + n_light);
+  //   float yield_significance = n_charm / err_yield;
+
+  //   if (yield_significance > max_charm_yield_signifiance) {
+  //     max_charm_yield_signifiance = yield_significance;
+  //     optimal_mva_cut = min;
+  //     optimal_charm_efficiency = eff_charm;
+  //     optimal_light_efficiency = eff_light;
+  //   }
+
+
+  // }
+
+  std::cout << "Optimal MVA cut: " << optimal_mva_cut
+	    << " with charm yield significance of " << max_charm_yield_signifiance
+	    << " charm (light) efficiency " << optimal_charm_efficiency << " (" << optimal_light_efficiency << ")"
+	    << " in 100/fb" << std::endl;
+	std::cout << "Estimated charm (light) yield: " << optimal_charm_yield << "(" << optimal_light_yield << ")" << std::endl;
+
+}

--- a/SimpleAnalysis/scripts/CharmTagPlots.C
+++ b/SimpleAnalysis/scripts/CharmTagPlots.C
@@ -20,30 +20,29 @@
 #include "PlotFunctions.h"
 
 
-
 float target_xsec = LookupCrossSection("CC_DIS");
 
-float target_lumi = 100*u_fb;
+float target_lumi = 100 * u_fb;
 
 float n_gen = -1;
 
 
-TEfficiency DifferentialTaggingEfficiency(TTree* data, plot_config draw_config, TString xvar, TString which="all", TString taggers="jet_sip3dtag")
+TEfficiency DifferentialTaggingEfficiency(TTree *data, plot_config draw_config, TString xvar, TString which = "all")
 {
   std::cout << "DifferentialTaggingEfficiency: processing " << which.Data() << " ... " << std::endl;
 
-  TH1F* tru_yield = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("tru_yield_%d", histUID)));
-  TH1F* tag_yield = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("tag_yield_%d", histUID)));
-  
-  TCut* tru_selection = nullptr;
-  TCut* tag_selection = nullptr;
+  TH1F *tru_yield = static_cast<TH1F *>(draw_config.htemplate->Clone(Form("tru_yield_%d", histUID)));
+  TH1F *tag_yield = static_cast<TH1F *>(draw_config.htemplate->Clone(Form("tag_yield_%d", histUID)));
 
-  if (which=="light") {
+  TCut *tru_selection = nullptr;
+  TCut *tag_selection = nullptr;
+
+  if (which == "light") {
     tru_selection = new TCut("jet_flavor < 4 || jet_flavor == 21");
-    tag_selection = new TCut(*tru_selection && TCut("jet_sip3dtag==1"));
+    tag_selection = new TCut(*tru_selection && TCut(draw_config.cuts));
   } else if (which == "charm") {
     tru_selection = new TCut("jet_flavor == 4");
-    tag_selection = new TCut(*tru_selection && TCut("jet_sip3dtag==1"));
+    tag_selection = new TCut(*tru_selection && TCut(draw_config.cuts));
   }
 
 
@@ -57,29 +56,28 @@ TEfficiency DifferentialTaggingEfficiency(TTree* data, plot_config draw_config, 
 
   if (tru_yield)
     delete tru_yield;
+
   if (tag_yield)
     delete tag_yield;
 
   histUID++;
 
   return eff;
-
 }
 
-
-TH1F* DifferentialTaggingYield(TTree* data, plot_config draw_config, TString xvar, TString which="all", TString taggers="jet_sip3dtag")
+TH1F* DifferentialTaggingYield(TTree *data, plot_config draw_config, TString xvar, TString which = "all")
 {
   std::cout << "DifferentialTaggingYield: processing " << which.Data() << " ... " << std::endl;
 
-  TH1F* tag_yield = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("%s_%s_tag_yield_%d", which.Data(), xvar.Data(), histUID)));
+  TH1F *tag_yield = static_cast<TH1F *>(draw_config.htemplate->Clone(Form("%s_%s_tag_yield_%d", which.Data(), xvar.Data(), histUID)));
   tag_yield->Sumw2();
 
-  TCut* tag_selection = nullptr;
+  TCut *tag_selection = nullptr;
 
-  if (which=="light") {
-    tag_selection = new TCut("(jet_flavor < 4 || jet_flavor == 21) && (jet_sip3dtag==1)");
+  if (which == "light") {
+    tag_selection = new TCut(TCut("(jet_flavor < 4 || jet_flavor == 21)") && TCut(draw_config.cuts));
   } else if (which == "charm") {
-    tag_selection = new TCut("jet_flavor == 4 && jet_sip3dtag==1");
+    tag_selection = new TCut(TCut("jet_flavor == 4") && TCut(draw_config.cuts));
   }
 
   // Add other analysis-level cuts to the tag selection
@@ -91,118 +89,116 @@ TH1F* DifferentialTaggingYield(TTree* data, plot_config draw_config, TString xva
   std::cout << "  Unnormalized Tag Yield: " << tag_yield->GetEntries() << std::endl;
   tag_yield->Scale(target_xsec * target_lumi / data->GetEntries());
   std::cout << "    Normalized Tag Yield: " << tag_yield->Integral() << std::endl;
-  
 
-  //auto tag_graph = new TGraphErrors(tag_yield);
+
+  // auto tag_graph = new TGraphErrors(tag_yield);
 
   histUID++;
   return tag_yield;
-
 }
 
-
-void DrawTagEfficiencyPlot(TCanvas* pad, TTree* data, plot_config draw_config, TString xvar) 
+void DrawTagEfficiencyPlot(TCanvas *pad, TTree *data, plot_config draw_config, TString xvar)
 {
+  auto light_eff = DifferentialTaggingEfficiency(data, draw_config, xvar, "light");
+  auto charm_eff = DifferentialTaggingEfficiency(data, draw_config, xvar, "charm");
 
-    auto light_eff = DifferentialTaggingEfficiency(data, draw_config, xvar, "light");
-    auto charm_eff = DifferentialTaggingEfficiency(data, draw_config, xvar, "charm");
-    
-    
-    // make a template histogram to fine-tune layout of the final plot
-    TH1F* htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
-    set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
-    set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
-    
-    // Configure plots
-    configure_plot<TEfficiency>(&charm_eff, draw_config, "charm");
-    configure_plot<TEfficiency>(&light_eff, draw_config, "light");
 
-    // Draw Layout
-    htemplate->Draw("HIST");
-    charm_eff.Draw("P E1 SAME");
-    light_eff.Draw("E1 P SAME");
-    
-    // Title
-    TLatex plot_title = make_title();
-    plot_title.Draw("SAME");
+  // make a template histogram to fine-tune layout of the final plot
+  TH1F *htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
 
-    // Configure the Pad
-    pad->SetLogy(draw_config.logy);
-    pad->SetLogx(draw_config.logx);
-    pad->SetGrid(1,1);
-    
-    
-    // Configure the Legend
-    TLegend* legend = smart_legend("lower right");
-    legend->SetFillStyle(0);
-    legend->SetBorderSize(0);
-    legend->AddEntry(&charm_eff, "Charm Jets", "lp");
-    legend->AddEntry(&light_eff, "Light Jets", "lp");
-    legend->Draw();
-    
-    pad->Update();
-    pad->SaveAs(Form("CharmTagPlot_tagging_efficiency_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+  set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
+  set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
 
-    // Cleanup
-    if (htemplate != nullptr)
-      delete htemplate;
-    if (legend != nullptr)
-      delete legend;
+  // Configure plots
+  configure_plot<TEfficiency>(&charm_eff, draw_config, "charm");
+  configure_plot<TEfficiency>(&light_eff, draw_config, "light");
 
+  // Draw Layout
+  htemplate->Draw("HIST");
+  charm_eff.Draw("P E1 SAME");
+  light_eff.Draw("E1 P SAME");
+
+  // Title
+  TLatex plot_title = make_title();
+  plot_title.Draw("SAME");
+
+  // Configure the Pad
+  pad->SetLogy(draw_config.logy);
+  pad->SetLogx(draw_config.logx);
+  pad->SetGrid(1, 1);
+
+
+  // Configure the Legend
+  TLegend *legend = smart_legend("lower right");
+  legend->SetFillStyle(0);
+  legend->SetBorderSize(0);
+  legend->AddEntry(&charm_eff, "Charm Jets", "lp");
+  legend->AddEntry(&light_eff, "Light Jets", "lp");
+  legend->Draw();
+
+  pad->Update();
+  pad->SaveAs(Form("CharmTagPlot_tagging_efficiency_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+
+  // Cleanup
+  if (htemplate != nullptr)
+    delete htemplate;
+
+  if (legend != nullptr)
+    delete legend;
 }
 
-void DrawTagYieldPlot(TCanvas* pad, TTree* data, plot_config draw_config, TString xvar)
+void DrawTagYieldPlot(TCanvas *pad, TTree *data, plot_config draw_config, TString xvar)
 {
+  std::cout << "Drawing tag yield plot for variable " << xvar << std::endl;
+  auto charm_yield = DifferentialTaggingYield(data, draw_config, xvar, "charm");
+  auto light_yield = DifferentialTaggingYield(data, draw_config, xvar, "light");
 
-    auto charm_yield = DifferentialTaggingYield(data, draw_config, xvar, "charm");
-    auto light_yield = DifferentialTaggingYield(data, draw_config, xvar, "light");
+  // Configure plots
 
-    // Configure plots
+  configure_plot<TH1F>(charm_yield, draw_config, "charm");
+  configure_plot<TH1F>(light_yield, draw_config, "light");
 
-    configure_plot<TH1F>(charm_yield, draw_config, "charm");
-    configure_plot<TH1F>(light_yield, draw_config, "light");
+  // generate template histogram
+  TH1F *htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
 
-    // generate template histogram
-    TH1F* htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
+  set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
+  set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
+  htemplate->SetXTitle(draw_config.xtitle);
+  htemplate->SetYTitle(draw_config.ytitle);
 
-    set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
-    set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
-    htemplate->SetXTitle( draw_config.xtitle );
-    htemplate->SetYTitle( draw_config.ytitle );
+  pad->SetGrid(1, 1);
+  pad->SetLogy(draw_config.logy);
+  pad->SetLogx(draw_config.logx);
 
-    pad->SetGrid(1,1);
-    pad->SetLogy(draw_config.logy);
-    pad->SetLogx(draw_config.logx);
+  htemplate->Draw("HIST");
+  charm_yield->Draw("E1 P SAME");
+  light_yield->Draw("E1 P SAME");
 
-    htemplate->Draw("HIST");
-    charm_yield->Draw("E1 P SAME");
-    light_yield->Draw("E1 P SAME");
-
-    TLatex plot_title = make_title();
-    plot_title.Draw("SAME");
-
-
-    // Legend
-    TLegend* legend = smart_legend("upper right");
-    legend->SetFillStyle(0);
-    legend->SetBorderSize(0);
-    legend->AddEntry(charm_yield, "Charm Jets", "lp");
-    legend->AddEntry(light_yield, "Light Jets", "lp");
-    legend->Draw();
-    pad->Update();
+  TLatex plot_title = make_title();
+  plot_title.Draw("SAME");
 
 
-    pad->SaveAs(Form("CharmTagPlot_tagging_yield_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+  // Legend
+  TLegend *legend = smart_legend("upper right");
+  legend->SetFillStyle(0);
+  legend->SetBorderSize(0);
+  legend->AddEntry(charm_yield, "Charm Jets", "lp");
+  legend->AddEntry(light_yield, "Light Jets", "lp");
+  legend->Draw();
+  pad->Update();
 
-    // Cleanup
-    if (htemplate != nullptr)
-      delete htemplate;
-    if (legend != nullptr)
-      delete legend;
 
+  pad->SaveAs(Form("CharmTagPlot_tagging_yield_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+
+  // Cleanup
+  if (htemplate != nullptr)
+    delete htemplate;
+
+  if (legend != nullptr)
+    delete legend;
 }
 
-float CutEfficiency(TTree* data, TCut cut, TString cutdesc = "")
+float CutEfficiency(TTree *data, TCut cut, TString cutdesc = "")
 {
   if (n_gen < 0) {
     n_gen = static_cast<float>(data->GetEntries());
@@ -211,16 +207,15 @@ float CutEfficiency(TTree* data, TCut cut, TString cutdesc = "")
   float n_yield = data->GetEntries(cut.GetTitle());
 
   TString desc = cutdesc;
+
   if (desc == "") {
     desc = cut.GetTitle();
   }
 
-  std::cout << setw(30) << desc << " efficiency: " << setprecision(4) << n_yield/n_gen * 100.0 << "%" << std::endl;
+  std::cout << setw(30) << desc << " efficiency: " << setprecision(4) << n_yield / n_gen * 100.0 << "%" << std::endl;
 
-  return (n_yield/n_gen);
-
+  return n_yield / n_gen;
 }
-
 
 void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern = "*/out.root")
 {
@@ -228,22 +223,22 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
   gStyle->SetOptStat(0);
 
   // Create the TCanvas
-  TCanvas* pad = new TCanvas("pad","",800,600);
-  TLegend * legend = nullptr;
-  TH1F* htemplate = nullptr;
+  TCanvas *pad       = new TCanvas("pad", "", 800, 600);
+  TLegend *legend    = nullptr;
+  TH1F    *htemplate = nullptr;
 
   auto default_data = new TChain("tree");
   default_data->SetTitle(input.Data());
   auto files = fileVector(Form("%s/%s/%s", dir.Data(), input.Data(), filePattern.Data()));
 
-  for (auto file : files) 
-    {
-      default_data->Add(file.c_str());
-    }
-
+  for (auto file : files)
+  {
+    default_data->Add(file.c_str());
+  }
 
 
   // Some basic cut efficiency information
+  std::cout << "Inclusive Jet Efficiency Information: " << std::endl;
   TCut selection("jet_n>0");
   CutEfficiency(default_data, selection, "Jet Reconstructed");
 
@@ -252,36 +247,35 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
   selection = selection && TCut("met_et > 10.0");
   CutEfficiency(default_data, selection, "MET > 10 GeV");
-  
+
   TCut main_preselection = selection;
 
   // Print charm jet MET cut efficiency
-  std::cout << "Char, Jet Efficiency Information: " << std::endl;
+  std::cout << "Charm Jet Efficiency Information: " << std::endl;
   selection = TCut("jet_n > 0 && TMath::Abs(jet_eta) < 3.0 && jet_flavor == 4");
   CutEfficiency(default_data, selection, "Charm Jet Reconstructed");
 
   selection = selection && TCut("met_et > 10.0");
   CutEfficiency(default_data, selection, "MET > 10 GeV");
-  
 
-  TTree* default_data_selected = default_data->CopyTree(main_preselection.GetTitle());
+
+  TTree *default_data_selected = default_data->CopyTree(main_preselection.GetTitle());
   default_data_selected->SetTitle(input.Data());
 
-  bool do_TagEffPlot = kTRUE;
-  bool do_TagYieldPlot = kFALSE; //kTRUE;
-  bool do_100fbProjPlot = kFALSE; //kTRUE;
-  bool do_Helicity = kFALSE; //kTRUE;
-
-
+  bool do_TagEffPlot    = kTRUE;
+  bool do_TagYieldPlot  = kTRUE;  // kTRUE;
+  bool do_100fbProjPlot = kTRUE; // kTRUE;
+  bool do_Helicity      = kFALSE; // kTRUE;
 
 
   // plot configurations
   plot_config draw_config;
-  if (xvar=="jet_pt") {
-    float xbins[] = {10,12.5,15,17.5,20,25,35,60};
-    int nbins = sizeof(xbins)/sizeof(xbins[0]) - 1;
+
+  if (xvar == "jet_pt") {
+    float xbins[] = { 10, 12.5, 15, 17.5, 20, 25, 35, 60 };
+    int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
     draw_config.htemplate = new TH1F(xvar, "", nbins, xbins);
-    draw_config.xlimits = std::vector<float>();
+    draw_config.xlimits   = std::vector<float>();
     draw_config.xlimits.push_back(0);
     draw_config.xlimits.push_back(60);
     draw_config.ylimits = std::vector<float>();
@@ -289,13 +283,14 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ylimits.push_back(1.0);
     draw_config.xtitle = "Reconstructed Jet p_{T} [GeV]";
     draw_config.ytitle = "#varepsilon_{tag}";
-    draw_config.logy = kTRUE;
-    draw_config.logx = kFALSE;
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
   } else if (xvar == "bjorken_x") {
-    float xbins[] = {0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0};
-    int nbins = sizeof(xbins)/sizeof(xbins[0]) - 1;
+    float xbins[] = { 0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0 };
+    int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
     draw_config.htemplate = new TH1F(xvar, "", nbins, xbins);
-    draw_config.xlimits = std::vector<float>();
+    draw_config.xlimits   = std::vector<float>();
     draw_config.xlimits.push_back(0.01);
     draw_config.xlimits.push_back(1.0);
     draw_config.ylimits = std::vector<float>();
@@ -303,13 +298,14 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ylimits.push_back(1.0);
     draw_config.xtitle = "Bjorken x";
     draw_config.ytitle = "#varepsilon_{tag}";
-    draw_config.logy = kTRUE;
-    draw_config.logx = kTRUE;
-  } else if (xvar == "jb_x") { 
-    float xbins[] = {0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0};
-    int nbins = sizeof(xbins)/sizeof(xbins[0]) - 1;
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kTRUE;
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+  } else if (xvar == "jb_x") {
+    float xbins[] = { 0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0 };
+    int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
     draw_config.htemplate = new TH1F(xvar, "", nbins, xbins);
-    draw_config.xlimits = std::vector<float>();
+    draw_config.xlimits   = std::vector<float>();
     draw_config.xlimits.push_back(0.01);
     draw_config.xlimits.push_back(1.0);
     draw_config.ylimits = std::vector<float>();
@@ -317,8 +313,9 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ylimits.push_back(1.0);
     draw_config.xtitle = "Reconstructed x_{JB}";
     draw_config.ytitle = "#varepsilon_{tag}";
-    draw_config.logy = kTRUE;
-    draw_config.logx = kTRUE;
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kTRUE;
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
   } else {
     do_TagEffPlot = kFALSE;
   }
@@ -343,9 +340,9 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
   //
   gStyle->SetErrorX(0.5);
 
-
-  if (xvar=="jet_pt") {
+  if (xvar == "jet_pt") {
     draw_config.ylimits = std::vector<float>();
+
     // draw_config.ylimits.push_back(0.1);
     // draw_config.ylimits.push_back(5000);
     draw_config.ylimits.push_back(0.0);
@@ -354,25 +351,92 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     draw_config.xtitle = "Reconstructed Jet p_{T} [GeV]";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
   } else if (xvar == "bjorken_x") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(0.1);
     draw_config.ylimits.push_back(5000);
     draw_config.xtitle = "Bjorken x";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
-  } else if (xvar == "jb_x") { 
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+  } else if (xvar == "jb_x") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(0.1);
     draw_config.ylimits.push_back(5000);
     draw_config.xtitle = "Reconstructed x_{JB}";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+  } else if (xvar == "jet_mlp_ktagger") {
+    draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
+    draw_config.xlimits   = std::vector<float>();
+    draw_config.xlimits.push_back(0);
+    draw_config.xlimits.push_back(1);
+    draw_config.ylimits = std::vector<float>();
+    draw_config.ylimits.push_back(0.1);
+    draw_config.ylimits.push_back(1e7);
+    draw_config.xtitle = "MLP Kaon-based Charm Jet Tagger Output";
+    draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "1==1";
+  } else if (xvar == "jet_mlp_eltagger") {
+    draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
+    draw_config.xlimits   = std::vector<float>();
+    draw_config.xlimits.push_back(0);
+    draw_config.xlimits.push_back(1);
+    draw_config.ylimits = std::vector<float>();
+    draw_config.ylimits.push_back(0.1);
+    draw_config.ylimits.push_back(1e7);
+    draw_config.xtitle = "MLP Electron-based Charm Jet Tagger Output";
+    draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "1==1";
+  } else if (xvar == "jet_mlp_mutagger") {
+    draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
+    draw_config.xlimits   = std::vector<float>();
+    draw_config.xlimits.push_back(0);
+    draw_config.xlimits.push_back(1);
+    draw_config.ylimits = std::vector<float>();
+    draw_config.ylimits.push_back(0.1);
+    draw_config.ylimits.push_back(1e7);
+    draw_config.xtitle = "MLP Muon-based Charm Jet Tagger Output";
+    draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "1==1";
+  } else if (xvar == "jet_mlp_ip3dtagger") {
+    draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
+    draw_config.xlimits   = std::vector<float>();
+    draw_config.xlimits.push_back(0);
+    draw_config.xlimits.push_back(1);
+    draw_config.ylimits = std::vector<float>();
+    draw_config.ylimits.push_back(0.1);
+    draw_config.ylimits.push_back(1e7);
+    draw_config.xtitle = "MLP sIP_{3D}-based Charm Jet Tagger Output";
+    draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "1==1";
+  } else if (xvar == "jet_mlp_globaltagger") {
+    draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
+    draw_config.xlimits   = std::vector<float>();
+    draw_config.xlimits.push_back(0);
+    draw_config.xlimits.push_back(1);
+    draw_config.ylimits = std::vector<float>();
+    draw_config.ylimits.push_back(0.1);
+    draw_config.ylimits.push_back(1e7);
+    draw_config.xtitle = "MLP Global Charm Jet Tagger Output";
+    draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
+    draw_config.logy   = kTRUE;
+    draw_config.logx   = kFALSE;
+    draw_config.cuts   = "1==1";
   } else {
     do_TagYieldPlot = kFALSE;
   }
 
 
-
-  if (do_TagYieldPlot) { 
+  if (do_TagYieldPlot) {
     DrawTagYieldPlot(pad, default_data_selected, draw_config, xvar);
   }
 
@@ -380,7 +444,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
   // Error Bands at 100/fb
   //
 
-  if (xvar=="jet_pt") {
+  if (xvar == "jet_pt") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(0.1);
     draw_config.ylimits.push_back(5000);
@@ -388,7 +452,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ytitle = "Relative Variation to Suppressed Strangeness";
   } else if (xvar == "bjorken_x") {
     draw_config.ytitle = "Relative Variation to Suppressed Strangeness";
-  } else if (xvar == "jb_x") { 
+  } else if (xvar == "jb_x") {
     draw_config.ytitle = "Relative Variation to Suppressed Strangeness";
   } else {
     do_100fbProjPlot = kFALSE;
@@ -400,21 +464,23 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     pad->Clear();
     gStyle->SetErrorX(0.5);
 
-    auto charm_yield = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "charm");
-    auto charm_yield_100fb = static_cast<TH1F*>(charm_yield->Clone("charm_yield_100fb"));
+    auto charm_yield       = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "charm");
+    auto charm_yield_100fb = static_cast<TH1F *>(charm_yield->Clone("charm_yield_100fb"));
+
     for (Int_t i = 1; i <= charm_yield_100fb->GetNbinsX(); i++) {
-      charm_yield_100fb->SetBinError(i, TMath::Sqrt(charm_yield_100fb->GetBinContent(i)) );
+      charm_yield_100fb->SetBinError(i, TMath::Sqrt(charm_yield_100fb->GetBinContent(i)));
     }
 
-    TH1F* light_yield = nullptr;
-    TH1F* light_yield_100fb = nullptr;
+    TH1F *light_yield       = nullptr;
+    TH1F *light_yield_100fb = nullptr;
 
     if (do_BkgSubtraction == kTRUE) {
       std::cout << "   For Yield Estimate, performing a naive background subtraction error estimation..." << std::endl;
-      light_yield = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "light");
-      light_yield_100fb = static_cast<TH1F*>(light_yield->Clone("light_yield_100fb"));
+      light_yield       = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "light");
+      light_yield_100fb = static_cast<TH1F *>(light_yield->Clone("light_yield_100fb"));
+
       for (Int_t i = 1; i <= light_yield_100fb->GetNbinsX(); i++) {
-        light_yield_100fb->SetBinError(i, TMath::Sqrt(light_yield_100fb->GetBinContent(i)) );
+        light_yield_100fb->SetBinError(i, TMath::Sqrt(light_yield_100fb->GetBinContent(i)));
       }
 
       // inflate the charm yield errors to account for "background subtraction"
@@ -423,80 +489,79 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
         float err_light = light_yield_100fb->GetBinError(i);
         float err_total = TMath::Sqrt(charm_yield_100fb->GetBinContent(i) + light_yield_100fb->GetBinContent(i));
 
-        float new_charm_err = TMath::Sqrt( TMath::Power(err_total, 2.0) + TMath::Power(err_light, 2.0) );
+        float new_charm_err = TMath::Sqrt(TMath::Power(err_total, 2.0) + TMath::Power(err_light, 2.0));
 
 
-        charm_yield_100fb->SetBinError(i, new_charm_err );
+        charm_yield_100fb->SetBinError(i, new_charm_err);
       }
-      
-
     }
 
     // Load alternative samples
     auto ccdis_20Rs2_data = new TChain("tree");
     files = fileVector(Form("%s/CC_DIS_e10_p275_lha_20Rs2/%s", dir.Data(), filePattern.Data()));
-  
-    for (auto file : files) 
-      {
-	ccdis_20Rs2_data->Add(file.c_str());
-      }
+
+    for (auto file : files)
+    {
+      ccdis_20Rs2_data->Add(file.c_str());
+    }
 
     auto ccdis_21Rs2_data = new TChain("tree");
     files = fileVector(Form("%s/CC_DIS_e10_p275_lha_21Rs2/%s", dir.Data(), filePattern.Data()));
-  
-    for (auto file : files) 
-      {
-	ccdis_21Rs2_data->Add(file.c_str());
-      }
 
-    TTree* ccdis_20Rs2_data_selected = ccdis_20Rs2_data->CopyTree(main_preselection.GetTitle());
-    TTree* ccdis_21Rs2_data_selected = ccdis_21Rs2_data->CopyTree(main_preselection.GetTitle());
+    for (auto file : files)
+    {
+      ccdis_21Rs2_data->Add(file.c_str());
+    }
+
+    TTree *ccdis_20Rs2_data_selected = ccdis_20Rs2_data->CopyTree(main_preselection.GetTitle());
+    TTree *ccdis_21Rs2_data_selected = ccdis_21Rs2_data->CopyTree(main_preselection.GetTitle());
 
     auto ccdis_20Rs2_yield = DifferentialTaggingYield(ccdis_20Rs2_data_selected, draw_config, xvar, "charm");
     auto ccdis_21Rs2_yield = DifferentialTaggingYield(ccdis_21Rs2_data_selected, draw_config, xvar, "charm");
 
-    auto ccdis_20Rs2_yield_100fb = static_cast<TH1F*>(ccdis_20Rs2_yield->Clone("20Rs2_yield_100fb"));
-    auto ccdis_21Rs2_yield_100fb = static_cast<TH1F*>(ccdis_21Rs2_yield->Clone("ccdis_21Rs2_yield_100fb"));
-  
+    auto ccdis_20Rs2_yield_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield->Clone("20Rs2_yield_100fb"));
+    auto ccdis_21Rs2_yield_100fb = static_cast<TH1F *>(ccdis_21Rs2_yield->Clone("ccdis_21Rs2_yield_100fb"));
+
 
     for (Int_t i = 1; i <= charm_yield_100fb->GetNbinsX(); i++) {
-      //charm_yield_100fb->SetBinError(i, TMath::Sqrt(charm_yield_100fb->GetBinContent(i)) );
-      ccdis_20Rs2_yield_100fb->SetBinError(i, TMath::Sqrt(ccdis_20Rs2_yield_100fb->GetBinContent(i)) );
+      // charm_yield_100fb->SetBinError(i,
+      // TMath::Sqrt(charm_yield_100fb->GetBinContent(i)) );
+      ccdis_20Rs2_yield_100fb->SetBinError(i, TMath::Sqrt(ccdis_20Rs2_yield_100fb->GetBinContent(i)));
 
       if (do_BkgSubtraction == kTRUE) {
-
         float err_charm = ccdis_20Rs2_yield_100fb->GetBinError(i);
         float err_light = light_yield_100fb->GetBinError(i);
         float err_total = TMath::Sqrt(ccdis_20Rs2_yield_100fb->GetBinContent(i) + light_yield_100fb->GetBinContent(i));
 
-        float new_charm_err = TMath::Sqrt( TMath::Power(err_total, 2.0) + TMath::Power(err_light, 2.0) );
+        float new_charm_err = TMath::Sqrt(TMath::Power(err_total, 2.0) + TMath::Power(err_light, 2.0));
         ccdis_20Rs2_yield_100fb->SetBinError(i, new_charm_err);
       }
 
-      ccdis_21Rs2_yield_100fb->SetBinError(i, TMath::Sqrt(ccdis_21Rs2_yield_100fb->GetBinContent(i)) );
+      ccdis_21Rs2_yield_100fb->SetBinError(i, TMath::Sqrt(ccdis_21Rs2_yield_100fb->GetBinContent(i)));
     }
-  
+
     // Generate the error band histogram for the suppressed case
-    TH1F* error_band_100fb = static_cast<TH1F*>(ccdis_20Rs2_yield_100fb->Clone("error_band_100fb"));
+    TH1F *error_band_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield_100fb->Clone("error_band_100fb"));
+
     for (Int_t i = 1; i <= error_band_100fb->GetNbinsX(); i++) {
-      error_band_100fb->SetBinError(i, error_band_100fb->GetBinError(i)/error_band_100fb->GetBinContent(i));
+      error_band_100fb->SetBinError(i, error_band_100fb->GetBinError(i) / error_band_100fb->GetBinContent(i));
       error_band_100fb->SetBinContent(i, 1.0);
     }
 
     // Draw the enhanced-suppressed range overlay
     std::cout << "Draw the Rs range band..." << std::endl;
-    TH1F* range_band_100fb = static_cast<TH1F*>(ccdis_20Rs2_yield_100fb->Clone("range_band_100fb"));
+    TH1F *range_band_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield_100fb->Clone("range_band_100fb"));
     range_band_100fb->Scale(-1.0);
     range_band_100fb->Add(ccdis_21Rs2_yield_100fb);
     range_band_100fb->Divide(ccdis_20Rs2_yield_100fb);
-  
+
     for (Int_t i = 1; i <= range_band_100fb->GetNbinsX(); i++) {
       range_band_100fb->SetBinError(i, 0.0);
       range_band_100fb->SetBinContent(i, range_band_100fb->GetBinContent(i) + 1.0);
     }
-    TGraphErrors* range_plot_100fb = new TGraphErrors(range_band_100fb);
-    range_plot_100fb->SetMarkerColor(kBlue-5);
-    range_plot_100fb->SetLineColor(kBlue-5);
+    TGraphErrors *range_plot_100fb = new TGraphErrors(range_band_100fb);
+    range_plot_100fb->SetMarkerColor(kBlue - 5);
+    range_plot_100fb->SetLineColor(kBlue - 5);
     range_plot_100fb->SetMarkerSize(2.0);
     range_plot_100fb->SetMarkerStyle(kOpenDiamond);
     range_plot_100fb->SetTitle("CT18ZNNLO with enhanced strangeness [R_{s}=0.863]");
@@ -505,13 +570,13 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     error_band_100fb->SetFillColor(kGray);
     error_band_100fb->SetMarkerSize(0.0001);
     error_band_100fb->SetMarkerColor(kGray);
-    error_band_100fb->SetTitle( "Stat. Uncertainty [CT18NNLO, R_{s}=2s/(#bar{u} + #bar{d})= 0.325 (suppressed)]" );
-  
+    error_band_100fb->SetTitle("Stat. Uncertainty [CT18NNLO, R_{s}=2s/(#bar{u} + #bar{d})= 0.325 (suppressed)]");
+
     htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
-    htemplate->SetXTitle( draw_config.xtitle );
-    htemplate->SetYTitle( draw_config.ytitle );
+    htemplate->SetXTitle(draw_config.xtitle);
+    htemplate->SetYTitle(draw_config.ytitle);
     htemplate->GetYaxis()->SetTitleSize(0.04);
-    set_axis_range(htemplate, 0.0, 2.0, "Y");
+    set_axis_range(htemplate, 0.0,                    2.0,                    "Y");
     set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
 
     htemplate->Draw("HIST");
@@ -528,21 +593,22 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
 
     pad->SetLogy(kFALSE);
-    if (xvar.Contains("_x")) 
+
+    if (xvar.Contains("_x"))
       pad->SetLogx(kTRUE);
 
-    pad->SetGrid(1,1);
+    pad->SetGrid(1, 1);
 
     // Legend
-    legend = smart_legend("lower left", 0.75,0.25);
+    legend = smart_legend("lower left", 0.75, 0.25);
     legend->SetFillStyle(0);
     legend->SetBorderSize(0);
     legend->AddEntry(error_band_100fb, "Stat. Uncertainty [CT18NNLO, R_{s}=2s/(#bar{u} + #bar{d})= 0.325 (suppressed)]", "lf");
-    legend->AddEntry(range_plot_100fb, "CT18ZNNLO with enhanced strangeness [R_{s}=0.863]", "lp");
+    legend->AddEntry(range_plot_100fb, "CT18ZNNLO with enhanced strangeness [R_{s}=0.863]",                              "lp");
     legend->Draw();
 
     pad->Update();
-  
+
     pad->SaveAs(Form("CharmTagPlot_tagging_yield_100fb_%s_%s.pdf", input.Data(), xvar.Data()));
 
 
@@ -555,14 +621,14 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
   // Polarized strangeness sensitivity estimate plot
   //
 
-  if (xvar=="jet_pt") {
+  if (xvar == "jet_pt") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(-100);
     draw_config.ylimits.push_back(100);
     draw_config.xtitle = "Reconstructed Jet p_{T} [GeV]";
     draw_config.ytitle = "Asymmetry Uncertainty [%]";
-    draw_config.logy = kFALSE;
-    draw_config.logx = kFALSE;
+    draw_config.logy   = kFALSE;
+    draw_config.logx   = kFALSE;
   } else {
     do_Helicity = kFALSE;
   }
@@ -572,42 +638,46 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     gStyle->SetErrorX(0.5);
 
     auto charm_yield = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "charm");
-    // auto light_yield = DifferentialTaggingYield(default_data_selected, draw_config, xvar, "light");
-    Float_t polarization_e=0.70;
-    Float_t polarization_p=0.70;
-    Float_t polarization  =0.70; // # single beam polarization
-    
-    
+
+    // auto light_yield = DifferentialTaggingYield(default_data_selected,
+    // draw_config, xvar, "light");
+    Float_t polarization_e = 0.70;
+    Float_t polarization_p = 0.70;
+    Float_t polarization   = 0.70; // # single beam polarization
+
+
     // Generate the error band histogram for the suppressed case
-    TH1F* dA_band_100fb = static_cast<TH1F*>(charm_yield->Clone("dA_band_100fb"));
-    Float_t n_gen = static_cast<Float_t>(default_data_selected->GetEntries());
+    TH1F   *dA_band_100fb = static_cast<TH1F *>(charm_yield->Clone("dA_band_100fb"));
+    Float_t n_gen         = static_cast<Float_t>(default_data_selected->GetEntries());
     std::cout << "N_gen: " << n_gen << std::endl;
+
     for (Int_t i = 1; i <= dA_band_100fb->GetNbinsX(); i++) {
       Float_t n_events = dA_band_100fb->GetBinContent(i);
-      Float_t err_n = TMath::Sqrt(n_events*(1.0 + polarization_e)/2.0);
-      Float_t dA = 0.0;
+      Float_t err_n    = TMath::Sqrt(n_events * (1.0 + polarization_e) / 2.0);
+      Float_t dA       = 0.0;
+
       if (err_n > 0.0) {
-	dA = 1.0/(err_n*polarization_p)*100.0;
+        dA = 1.0 / (err_n * polarization_p) * 100.0;
       }
       dA_band_100fb->SetBinError(i, dA);
       dA_band_100fb->SetBinContent(i, 0.0);
     }
-  
+
     htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
-    htemplate->SetXTitle( draw_config.xtitle );
-    htemplate->SetYTitle( draw_config.ytitle );
+    htemplate->SetXTitle(draw_config.xtitle);
+    htemplate->SetYTitle(draw_config.ytitle);
     set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
     set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
 
-    dA_band_100fb->SetFillColor(kBlue+2);
-    dA_band_100fb->SetLineColor(kBlue+2);
+    dA_band_100fb->SetFillColor(kBlue + 2);
+    dA_band_100fb->SetLineColor(kBlue + 2);
     dA_band_100fb->SetMarkerSize(0.001);
-    dA_band_100fb->SetMarkerColor(kBlue+2);
-    dA_band_100fb->SetFillColorAlpha(kBlue+0.2, 0.5);
+    dA_band_100fb->SetMarkerColor(kBlue + 2);
+    dA_band_100fb->SetFillColorAlpha(kBlue + 0.2, 0.5);
 
     htemplate->Draw("HIST");
     dA_band_100fb->Draw("E2 SAME");
-    
+
     TLine ZeroLine(draw_config.xlimits[0], 0.0, draw_config.xlimits[1], 0.0);
     ZeroLine.SetLineWidth(2);
     ZeroLine.SetLineColor(kBlack);
@@ -620,34 +690,32 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     pad->SetLogy(draw_config.logx);
     pad->SetLogx(draw_config.logy);
 
-    pad->SetGrid(1,1);
+    pad->SetGrid(1, 1);
 
     // Legend
-    TLegend* legend = smart_legend("upper right", 0.25,0.10);
+    TLegend *legend = smart_legend("upper right", 0.25, 0.10);
     legend->SetFillStyle(0);
     legend->SetBorderSize(0);
     legend->AddEntry(dA_band_100fb, "p=70%", "f");
     legend->Draw();
 
     pad->Update();
-  
+
     pad->SaveAs(Form("CharmTagPlot_dA_strange_helicity_100fb_%s_%s.pdf", input.Data(), xvar.Data()));
-    
-  
   }
-  
-  
+
+
   //
   // Generator-level plots
-  // 
+  //
 
   pad->Clear();
 
   bool do_GenJetPlot = kTRUE;
 
-  if (xvar=="GenJet.PT") {
-    float xbins[] = {0, 2.5, 5.0, 7.5, 10,12.5,15,20,25,35,60};
-    int nbins = sizeof(xbins)/sizeof(xbins[0]) - 1;
+  if (xvar == "GenJet.PT") {
+    float xbins[] = { 0, 2.5, 5.0, 7.5, 10, 12.5, 15, 20, 25, 35, 60 };
+    int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
     draw_config.htemplate = new TH1F(xvar, "", nbins, xbins);
 
     draw_config.xlimits = std::vector<float>();
@@ -669,22 +737,21 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
 
   if (do_GenJetPlot == kTRUE) {
+    pad = new TCanvas("pad", "", 900, 1200);
 
-    pad = new TCanvas("pad","",900,1200);
-    
     // Load Delphes samples for this plot
     auto delphes_data = new TChain("Delphes");
     files = fileVector(Form("%s/../%s/%s", dir.Data(), input.Data(), filePattern.Data()));
-    
-    for (auto file : files) 
-      {
-	delphes_data->Add(file.c_str());
-      }
 
-    TH1F* light_genjets = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("GenJet_light_%s_%d", xvar.Data(), getHistUID())));
+    for (auto file : files)
+    {
+      delphes_data->Add(file.c_str());
+    }
+
+    TH1F *light_genjets = static_cast<TH1F *>(draw_config.htemplate->Clone(Form("GenJet_light_%s_%d", xvar.Data(), getHistUID())));
     light_genjets->Sumw2();
 
-    TH1F* charm_genjets = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("GenJet_charm_%s_%d", xvar.Data(), getHistUID())));
+    TH1F *charm_genjets = static_cast<TH1F *>(draw_config.htemplate->Clone(Form("GenJet_charm_%s_%d", xvar.Data(), getHistUID())));
     charm_genjets->Sumw2();
 
     delphes_data->Project(light_genjets->GetName(), xvar.Data(), "");
@@ -692,16 +759,17 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     // Transform these into differential cross-section distributions
     Float_t n_gen = static_cast<float>(delphes_data->GetEntries());
-    for (Int_t ibin = 1; ibin <= light_genjets->GetNbinsX(); ibin++) {
-      Float_t dydx = light_genjets->GetBinContent(ibin)*target_lumi*target_xsec/n_gen/light_genjets->GetBinWidth(ibin);
-      Float_t dydx_relerr = light_genjets->GetBinError(ibin)/light_genjets->GetBinContent(ibin);
-      light_genjets->SetBinContent(ibin, dydx);
-      light_genjets->SetBinError(ibin, dydx*dydx_relerr);
 
-      dydx = charm_genjets->GetBinContent(ibin)*target_lumi*target_xsec/n_gen/charm_genjets->GetBinWidth(ibin);
-      dydx_relerr = charm_genjets->GetBinError(ibin)/charm_genjets->GetBinContent(ibin);
+    for (Int_t ibin = 1; ibin <= light_genjets->GetNbinsX(); ibin++) {
+      Float_t dydx        = light_genjets->GetBinContent(ibin) * target_lumi * target_xsec / n_gen / light_genjets->GetBinWidth(ibin);
+      Float_t dydx_relerr = light_genjets->GetBinError(ibin) / light_genjets->GetBinContent(ibin);
+      light_genjets->SetBinContent(ibin, dydx);
+      light_genjets->SetBinError(ibin, dydx * dydx_relerr);
+
+      dydx        = charm_genjets->GetBinContent(ibin) * target_lumi * target_xsec / n_gen / charm_genjets->GetBinWidth(ibin);
+      dydx_relerr = charm_genjets->GetBinError(ibin) / charm_genjets->GetBinContent(ibin);
       charm_genjets->SetBinContent(ibin, dydx);
-      charm_genjets->SetBinError(ibin, dydx*dydx_relerr);
+      charm_genjets->SetBinError(ibin, dydx * dydx_relerr);
     }
 
     configure_plot<TH1F>(charm_genjets, draw_config, "charm");
@@ -709,27 +777,27 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     // generate template histogram
     htemplate = new TH1F("htemplate", "", 1, draw_config.xlimits[0], draw_config.xlimits[1]);
-    
+
     set_axis_range(htemplate, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
     set_axis_range(htemplate, draw_config.xlimits[0], draw_config.xlimits[1], "X");
-    htemplate->SetXTitle( draw_config.xtitle );
-    htemplate->SetYTitle( draw_config.ytitle );
+    htemplate->SetXTitle(draw_config.xtitle);
+    htemplate->SetYTitle(draw_config.ytitle);
 
     set_axis_range(charm_genjets, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
     set_axis_range(charm_genjets, draw_config.xlimits[0], draw_config.xlimits[1], "X");
-    charm_genjets->SetXTitle( draw_config.xtitle );
-    charm_genjets->SetYTitle( draw_config.ytitle );
+    charm_genjets->SetXTitle(draw_config.xtitle);
+    charm_genjets->SetYTitle(draw_config.ytitle);
 
     set_axis_range(light_genjets, draw_config.ylimits[0], draw_config.ylimits[1], "Y");
     set_axis_range(light_genjets, draw_config.xlimits[0], draw_config.xlimits[1], "X");
-    light_genjets->SetXTitle( draw_config.xtitle );
-    light_genjets->SetYTitle( draw_config.ytitle );
+    light_genjets->SetXTitle(draw_config.xtitle);
+    light_genjets->SetYTitle(draw_config.ytitle);
 
 
     pad->cd();
     pad->SetLogy(draw_config.logy);
     pad->SetLogx(draw_config.logx);
-    pad->SetGrid(1,1);
+    pad->SetGrid(1, 1);
     pad->Update();
 
     auto rp = new TRatioPlot(charm_genjets, light_genjets);
@@ -747,9 +815,9 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     rp->SetLowBottomMargin(0.55);
 
     rp->GetLowerRefYaxis()->SetRangeUser(0.0, 0.05);
-    rp->GetLowerRefYaxis()->SetNdivisions(5,1,0,kFALSE);
+    rp->GetLowerRefYaxis()->SetNdivisions(5, 1, 0, kFALSE);
     rp->GetLowYaxis()->SetRangeUser(-0.01, 0.051);
-    rp->GetLowYaxis()->SetNdivisions(5,1,0,kTRUE);
+    rp->GetLowYaxis()->SetNdivisions(5, 1, 0, kTRUE);
 
     TLatex plot_title = make_title();
     plot_title.Draw("SAME");
@@ -757,14 +825,14 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     // Legend
     rp->GetUpperPad()->cd();
-    TLegend* legend = smart_legend("lower left", 0.55, 0.15);
+    TLegend *legend = smart_legend("lower left", 0.55, 0.15);
     legend->SetFillStyle(0);
     legend->SetBorderSize(0);
-    legend->AddEntry(light_genjets, "All Jets [CT18NNLO]", "lp");
+    legend->AddEntry(light_genjets, "All Jets [CT18NNLO]",   "lp");
     legend->AddEntry(charm_genjets, "Charm Jets [CT18NNLO]", "lp");
     legend->Draw();
 
-    rp->GetUpperPad()->SetGrid(1,1);
+    rp->GetUpperPad()->SetGrid(1, 1);
 
     pad->Update();
     pad->SaveAs(Form("CharmTagPlot_differential_xs_%s_%s.pdf", delphes_data->GetTitle(), xvar.Data()));
@@ -772,10 +840,8 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     // Cleanup
     if (htemplate != nullptr)
       delete htemplate;
+
     if (legend != nullptr)
       delete legend;
-
-
-  }  
-  
+  }
 }

--- a/SimpleAnalysis/scripts/CharmTagPlots.C
+++ b/SimpleAnalysis/scripts/CharmTagPlots.C
@@ -11,6 +11,7 @@
 #include "TLine.h"
 #include "TLatex.h"
 #include "TRatioPlot.h"
+#include "TFile.h"
 
 #include <glob.h>
 #include <iostream>
@@ -138,6 +139,7 @@ void DrawTagEfficiencyPlot(TCanvas *pad, TTree *data, plot_config draw_config, T
 
   pad->Update();
   pad->SaveAs(Form("CharmTagPlot_tagging_efficiency_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+  pad->SaveAs(Form("CharmTagPlot_tagging_efficiency_%s_%s.C", data->GetTitle(), xvar.Data()));
 
   // Cleanup
   if (htemplate != nullptr)
@@ -189,6 +191,7 @@ void DrawTagYieldPlot(TCanvas *pad, TTree *data, plot_config draw_config, TStrin
 
 
   pad->SaveAs(Form("CharmTagPlot_tagging_yield_%s_%s.pdf", data->GetTitle(), xvar.Data()));
+  pad->SaveAs(Form("CharmTagPlot_tagging_yield_%s_%s.C", data->GetTitle(), xvar.Data()));
 
   // Cleanup
   if (htemplate != nullptr)
@@ -262,8 +265,8 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
   TTree *default_data_selected = default_data->CopyTree(main_preselection.GetTitle());
   default_data_selected->SetTitle(input.Data());
 
-  bool do_TagEffPlot    = kTRUE;
-  bool do_TagYieldPlot  = kTRUE;  // kTRUE;
+  bool do_TagEffPlot    = kFALSE;
+  bool do_TagYieldPlot  = kFALSE;  // kTRUE;
   bool do_100fbProjPlot = kTRUE; // kTRUE;
   bool do_Helicity      = kFALSE; // kTRUE;
 
@@ -285,7 +288,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ytitle = "#varepsilon_{tag}";
     draw_config.logy   = kTRUE;
     draw_config.logx   = kFALSE;
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else if (xvar == "bjorken_x") {
     float xbins[] = { 0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0 };
     int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
@@ -300,7 +303,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ytitle = "#varepsilon_{tag}";
     draw_config.logy   = kTRUE;
     draw_config.logx   = kTRUE;
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else if (xvar == "jb_x") {
     float xbins[] = { 0.01, 0.043333, 0.076666, 0.1, 0.25, 0.5, 1.0 };
     int   nbins   = sizeof(xbins) / sizeof(xbins[0]) - 1;
@@ -315,7 +318,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     draw_config.ytitle = "#varepsilon_{tag}";
     draw_config.logy   = kTRUE;
     draw_config.logx   = kTRUE;
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else {
     do_TagEffPlot = kFALSE;
   }
@@ -351,21 +354,21 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     draw_config.xtitle = "Reconstructed Jet p_{T} [GeV]";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else if (xvar == "bjorken_x") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(0.1);
     draw_config.ylimits.push_back(5000);
     draw_config.xtitle = "Bjorken x";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else if (xvar == "jb_x") {
     draw_config.ylimits = std::vector<float>();
     draw_config.ylimits.push_back(0.1);
     draw_config.ylimits.push_back(5000);
     draw_config.xtitle = "Reconstructed x_{JB}";
     draw_config.ytitle = "#varepsilon_{tag} #times #sigma_{CC-DIS} #times 100fb^{-1}";
-    draw_config.cuts   = "jet_mlp_globaltagger>0.84";
+    draw_config.cuts   = "jet_sip3dtag==1";
   } else if (xvar == "jet_mlp_ktagger") {
     draw_config.htemplate = new TH1F(xvar, "", 50, -0.00001, 1.00001);
     draw_config.xlimits   = std::vector<float>();
@@ -496,32 +499,41 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
       }
     }
 
+    std::map<TString, TString> alt_samples;
+    alt_samples["CC_DIS_e10_p275_lha_21Rs2"] = "CT18ZNNLO with enhanced strangeness [R_{s}=0.863]";
+    alt_samples["CC_DIS_e10_p275_CT18ANNLO"] = "CT18ANNLO";
+    //alt_samples["CC_DIS_e10_p275_lha_22Rs2"] = "CT18ZNNLO with intermediate strangeness (22Rs2)";
+    //alt_samples["CC_DIS_e10_p275_lha_22Rs2ver3"] = "R_{s}^{INT}=0.594";
+    //alt_samples["CC_DIS_e10_p275_MMHT2014nnlo68cl"] = "MMHT2014nnlo68cl";
+    //alt_samples["CC_DIS_e10_p275_NNPDF31_nnlo_as_0118"] = "NNPDF31_nnlo_as_0118";
+
+    std::map<TString, Int_t> alt_marker;
+    alt_marker["CC_DIS_e10_p275_lha_21Rs2"] = kOpenDiamond;
+    alt_marker["CC_DIS_e10_p275_CT18ANNLO"] = kOpenCrossX;
+    alt_marker["CC_DIS_e10_p275_lha_22Rs2ver3" ] = kOpenCross;
+
+    std::map<TString, Int_t> alt_color;
+    alt_color["CC_DIS_e10_p275_lha_21Rs2"] = kBlue - 5;
+    alt_color["CC_DIS_e10_p275_CT18ANNLO"] = kViolet - 5;
+    alt_color["CC_DIS_e10_p275_lha_22Rs2ver3" ] = kSpring - 6;
+    
+
+    
+
+
     // Load alternative samples
     auto ccdis_20Rs2_data = new TChain("tree");
     files = fileVector(Form("%s/CC_DIS_e10_p275_lha_20Rs2/%s", dir.Data(), filePattern.Data()));
-
     for (auto file : files)
     {
       ccdis_20Rs2_data->Add(file.c_str());
     }
 
-    auto ccdis_21Rs2_data = new TChain("tree");
-    files = fileVector(Form("%s/CC_DIS_e10_p275_lha_21Rs2/%s", dir.Data(), filePattern.Data()));
-
-    for (auto file : files)
-    {
-      ccdis_21Rs2_data->Add(file.c_str());
-    }
-
+    std::cout << "Running pre-selection on alternative samples." << std::endl;
+    std::cout << "... suppressed strangeness ..." << std::endl;
     TTree *ccdis_20Rs2_data_selected = ccdis_20Rs2_data->CopyTree(main_preselection.GetTitle());
-    TTree *ccdis_21Rs2_data_selected = ccdis_21Rs2_data->CopyTree(main_preselection.GetTitle());
-
     auto ccdis_20Rs2_yield = DifferentialTaggingYield(ccdis_20Rs2_data_selected, draw_config, xvar, "charm");
-    auto ccdis_21Rs2_yield = DifferentialTaggingYield(ccdis_21Rs2_data_selected, draw_config, xvar, "charm");
-
     auto ccdis_20Rs2_yield_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield->Clone("20Rs2_yield_100fb"));
-    auto ccdis_21Rs2_yield_100fb = static_cast<TH1F *>(ccdis_21Rs2_yield->Clone("ccdis_21Rs2_yield_100fb"));
-
 
     for (Int_t i = 1; i <= charm_yield_100fb->GetNbinsX(); i++) {
       // charm_yield_100fb->SetBinError(i,
@@ -537,7 +549,6 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
         ccdis_20Rs2_yield_100fb->SetBinError(i, new_charm_err);
       }
 
-      ccdis_21Rs2_yield_100fb->SetBinError(i, TMath::Sqrt(ccdis_21Rs2_yield_100fb->GetBinContent(i)));
     }
 
     // Generate the error band histogram for the suppressed case
@@ -548,24 +559,8 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
       error_band_100fb->SetBinContent(i, 1.0);
     }
 
-    // Draw the enhanced-suppressed range overlay
-    std::cout << "Draw the Rs range band..." << std::endl;
-    TH1F *range_band_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield_100fb->Clone("range_band_100fb"));
-    range_band_100fb->Scale(-1.0);
-    range_band_100fb->Add(ccdis_21Rs2_yield_100fb);
-    range_band_100fb->Divide(ccdis_20Rs2_yield_100fb);
 
-    for (Int_t i = 1; i <= range_band_100fb->GetNbinsX(); i++) {
-      range_band_100fb->SetBinError(i, 0.0);
-      range_band_100fb->SetBinContent(i, range_band_100fb->GetBinContent(i) + 1.0);
-    }
-    TGraphErrors *range_plot_100fb = new TGraphErrors(range_band_100fb);
-    range_plot_100fb->SetMarkerColor(kBlue - 5);
-    range_plot_100fb->SetLineColor(kBlue - 5);
-    range_plot_100fb->SetMarkerSize(2.0);
-    range_plot_100fb->SetMarkerStyle(kOpenDiamond);
-    range_plot_100fb->SetTitle("CT18ZNNLO with enhanced strangeness [R_{s}=0.863]");
-
+    // Now handle the suppressed-only error band
     error_band_100fb->SetLineColor(kGray);
     error_band_100fb->SetFillColor(kGray);
     error_band_100fb->SetMarkerSize(0.0001);
@@ -581,7 +576,131 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     htemplate->Draw("HIST");
     error_band_100fb->Draw("E2 SAME");
-    range_plot_100fb->Draw("E1 SAME P");
+
+
+    // Legend
+    legend = smart_legend("lower left", 0.75, 0.25);
+    legend->SetFillStyle(0);
+    legend->SetBorderSize(0);
+    legend->AddEntry(error_band_100fb, "Stat. Uncertainty [CT18NNLO, R_{s}=2s/(#bar{u} + #bar{d})= 0.325 (suppressed)]", "lf");
+
+
+    // Other alternative samples
+
+    Int_t plot_index = 0;
+    for (auto& alt_sample : alt_samples) {
+      auto alt_tree = new TChain("tree");
+      files = fileVector(Form("%s/%s/%s", dir.Data(), alt_sample.first.Data(), filePattern.Data()));
+
+      if (files.size() == 0) {
+	std::cout << "Sample " << alt_sample.first.Data() << " appears to contain no files - check the name of the directory, etc." << std::endl;
+	exit(0);
+      }
+
+      for (auto file : files)
+	{
+	  // Check file first
+	  TFile* testfile = TFile::Open(file.c_str());
+	  if (testfile != nullptr) {
+	    alt_tree->Add(file.c_str());
+	    delete testfile;
+	  } else {
+	    std::cout << "File " << file.c_str() << " is damaged!" << std::endl;
+	  }
+	}
+
+      std::cout << "Generated events in sample " << alt_sample.first.Data() << ": " << alt_tree->GetEntries() << std::endl;
+
+      TTree* alt_selected = alt_tree->CopyTree(main_preselection.GetTitle());
+      auto yield = DifferentialTaggingYield(alt_selected, draw_config, xvar, "charm");
+
+      delete alt_selected;
+
+      auto yield_100fb = static_cast<TH1F *>(yield->Clone(alt_sample.second));
+      
+
+      for (Int_t i = 1; i <= charm_yield_100fb->GetNbinsX(); i++) {
+	yield_100fb->SetBinError(i, TMath::Sqrt(yield_100fb->GetBinContent(i)));
+      }
+      
+      // Draw the enhanced-suppressed range overlay
+      std::cout << "Draw " << alt_sample.second << std::endl;
+      TH1F *range_band_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield_100fb->Clone(Form("range plot %s", alt_sample.second.Data())));
+      range_band_100fb->Scale(-1.0);
+      range_band_100fb->Add(yield_100fb);
+      range_band_100fb->Divide(ccdis_20Rs2_yield_100fb);
+      
+      for (Int_t i = 1; i <= range_band_100fb->GetNbinsX(); i++) {
+	range_band_100fb->SetBinError(i, 0.0);
+	range_band_100fb->SetBinContent(i, range_band_100fb->GetBinContent(i) + 1.0);
+      }
+      TGraphErrors *range_plot_100fb = new TGraphErrors(range_band_100fb);
+      range_plot_100fb->SetName(Form("range_plot_100fb_%d", plot_index));
+      range_plot_100fb->SetMarkerColor(alt_color[alt_sample.first]);
+      range_plot_100fb->SetLineColor(alt_color[alt_sample.first]);
+      range_plot_100fb->SetMarkerSize(2.0);
+      range_plot_100fb->SetMarkerStyle(alt_marker[alt_sample.first]);
+      range_plot_100fb->SetTitle(alt_sample.second.Data());
+
+      range_plot_100fb->Draw("E1 SAME P");
+      legend->AddEntry(range_plot_100fb, alt_sample.second.Data(),                              "lp");
+
+      plot_index++;
+    }
+
+
+    // auto ccdis_21Rs2_data = new TChain("tree");
+    // files = fileVector(Form("%s/CC_DIS_e10_p275_lha_21Rs2/%s", dir.Data(), filePattern.Data()));
+
+    // for (auto file : files)
+    // {
+    //   ccdis_21Rs2_data->Add(file.c_str());
+    // }
+
+    // auto ccdis_CT18ANNLO_data = new TChain("tree");
+    // files = fileVector(Form("%s/CC_DIS_e10_p275_CT18ANNLO/%s", dir.Data(), filePattern.Data()));
+
+    // for (auto file : files)
+    // {
+    //   ccdis_CT18ANNLO_data->Add(file.c_str());
+    // }
+
+
+    // std::cout << "... enhanced strangeness ..." << std::endl;
+    // TTree *ccdis_21Rs2_data_selected = ccdis_21Rs2_data->CopyTree(main_preselection.GetTitle());
+    // std::cout << "... CT18ANNLO ..." << std::endl;
+    // TTree *ccdis_CT18ANNLO_data_selected = ccdis_CT18ANNLO_data->CopyTree(main_preselection.GetTitle());
+
+    // auto ccdis_21Rs2_yield = DifferentialTaggingYield(ccdis_21Rs2_data_selected, draw_config, xvar, "charm");
+    // auto ccdis_CT18ANNLO_yield = DifferentialTaggingYield(ccdis_CT18ANNLO_data_selected, draw_config, xvar, "charm");
+
+    // auto ccdis_21Rs2_yield_100fb = static_cast<TH1F *>(ccdis_21Rs2_yield->Clone("ccdis_21Rs2_yield_100fb"));
+    // auto ccdis_CT18ANNLO_yield_100fb = static_cast<TH1F *>(ccdis_CT18ANNLO_yield->Clone("ccdis_CT18ANNLO_yield_100fb"));
+
+
+
+
+    // // Draw the CT18ANNLO-suppressed range overlay
+    // std::cout << "Draw the Rs range band for CT18ANNLO vs. Suppressed Strangeness..." << std::endl;
+    // TH1F *range_CT18ANNLO_band_100fb = static_cast<TH1F *>(ccdis_20Rs2_yield_100fb->Clone("range_CT18ANNLO_band_100fb"));
+    // range_CT18ANNLO_band_100fb->Scale(-1.0);
+    // range_CT18ANNLO_band_100fb->Add(ccdis_CT18ANNLO_yield_100fb);
+    // range_CT18ANNLO_band_100fb->Divide(ccdis_20Rs2_yield_100fb);
+
+    // for (Int_t i = 1; i <= range_CT18ANNLO_band_100fb->GetNbinsX(); i++) {
+    //   range_CT18ANNLO_band_100fb->SetBinError(i, 0.0);
+    //   range_CT18ANNLO_band_100fb->SetBinContent(i, range_CT18ANNLO_band_100fb->GetBinContent(i) + 1.0);
+    // }
+    // TGraphErrors *range_CT18ANNLO_plot_100fb = new TGraphErrors(range_CT18ANNLO_band_100fb);
+    // range_CT18ANNLO_plot_100fb->SetMarkerColor(kGreen - 5);
+    // range_CT18ANNLO_plot_100fb->SetLineColor(kGreen - 5);
+    // range_CT18ANNLO_plot_100fb->SetMarkerSize(2.0);
+    // range_CT18ANNLO_plot_100fb->SetMarkerStyle(kOpenTriangleUp);
+    // range_CT18ANNLO_plot_100fb->SetTitle("CT18ANNLO");
+
+
+    // range_plot_100fb->Draw("E1 SAME P");
+    // range_CT18ANNLO_plot_100fb->Draw("E1 SAME P");
 
     TLine OneLine(draw_config.xlimits[0], 1.0, draw_config.xlimits[1], 1.0);
     OneLine.SetLineWidth(2);
@@ -599,17 +718,12 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     pad->SetGrid(1, 1);
 
-    // Legend
-    legend = smart_legend("lower left", 0.75, 0.25);
-    legend->SetFillStyle(0);
-    legend->SetBorderSize(0);
-    legend->AddEntry(error_band_100fb, "Stat. Uncertainty [CT18NNLO, R_{s}=2s/(#bar{u} + #bar{d})= 0.325 (suppressed)]", "lf");
-    legend->AddEntry(range_plot_100fb, "CT18ZNNLO with enhanced strangeness [R_{s}=0.863]",                              "lp");
     legend->Draw();
 
     pad->Update();
 
     pad->SaveAs(Form("CharmTagPlot_tagging_yield_100fb_%s_%s.pdf", input.Data(), xvar.Data()));
+    pad->SaveAs(Form("CharmTagPlot_tagging_yield_100fb_%s_%s.C", input.Data(), xvar.Data()));
 
 
     if (htemplate != nullptr)
@@ -702,6 +816,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
     pad->Update();
 
     pad->SaveAs(Form("CharmTagPlot_dA_strange_helicity_100fb_%s_%s.pdf", input.Data(), xvar.Data()));
+    pad->SaveAs(Form("CharmTagPlot_dA_strange_helicity_100fb_%s_%s.C", input.Data(), xvar.Data()));
   }
 
 
@@ -836,6 +951,7 @@ void CharmTagPlots(TString dir, TString input, TString xvar, TString filePattern
 
     pad->Update();
     pad->SaveAs(Form("CharmTagPlot_differential_xs_%s_%s.pdf", delphes_data->GetTitle(), xvar.Data()));
+    pad->SaveAs(Form("CharmTagPlot_differential_xs_%s_%s.C", delphes_data->GetTitle(), xvar.Data()));
 
     // Cleanup
     if (htemplate != nullptr)

--- a/SimpleAnalysis/scripts/KaonIDStudy.C
+++ b/SimpleAnalysis/scripts/KaonIDStudy.C
@@ -1,0 +1,156 @@
+#include "TROOT.h"
+#include "TChain.h"
+#include "TEfficiency.h"
+#include "TH1.h"
+#include "TGraphErrors.h"
+#include "TCut.h"
+#include "TCanvas.h"
+#include "TStyle.h"
+#include "TLegend.h"
+#include "TMath.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TRatioPlot.h"
+#include "TString.h"
+
+#include <glob.h>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+
+#include "PlotFunctions.h"
+
+void              KaonIDStudy(TString dir, TString input, TString trackname = "barrelDircTrack", TString filePattern = "*/out.root")
+{
+  auto data = new TChain("tree");
+
+  data->SetTitle(input.Data());
+  auto files = fileVector(Form("%s/%s/%s", dir.Data(), input.Data(), filePattern.Data()));
+
+  for (auto file : files)
+  {
+    data->Add(file.c_str());
+  }
+
+
+  // TString trackname = "CF4RICHTrack";
+  // TString trackname = "mRICHTrack";
+  // TString trackname = "barrelDircTrack";
+  // TString trackname = "tofBarrelTrack";
+  // TString trackname = "dRICHagTrack";
+
+  Float_t etaMin = -8;
+  Float_t etaMax = 8;
+
+  TCut   *cut_fiducial = nullptr;
+  Float_t xmin         = 0.0;
+  Float_t xmax         = 55.0;
+
+  if (trackname == "mRICHTrack") {
+    // mRICH
+    etaMin       = -4.0;
+    etaMax       = -1.0;
+    xmax         = 12.0;
+  } else if (trackname == "barrelDircTrack") {
+    // barrel DIRC
+    etaMin       = -1.0;
+    etaMax       = 1.0;
+    xmax         = 55.0;
+  } else if (trackname == "CF4RICHTrack") {
+    // CF4RICH
+    etaMin       = 1.0;
+    etaMax       = 4.0;
+  } else if (trackname == "tofBarrelTrack") {
+    // TOF Barrel Detector
+    etaMin       = -2.0;
+    etaMax       = 2.0;
+  } else if (trackname == "dRICHTrack") {
+    // dualRICH, aerogel-based
+    etaMin       = 1.48;
+    etaMax       = 3.91;
+    xmax         = 75.0;
+  }
+  cut_fiducial = new TCut(Form("%0.1f < pid_track_eta && pid_track_eta < %0.1f && pid_track_pt>0.1", etaMin, etaMax));
+
+  Float_t xbinsize = 0.5;
+  Int_t   nbinsx   = TMath::Ceil((xmax - xmin) / xbinsize);
+
+  TCut                        cut_truekaon("((pid_track_pid & 0xffff0000) >> 16) == 321");
+  TCut                        cut_recokaon("(pid_track_pid & 0xffff) == 321");
+  TCut                        cut_truepion("((pid_track_pid & 0xffff0000) >> 16) == 211");
+  TCut                        cut_recopion("(pid_track_pid & 0xffff) == 211");
+
+  plot_config draw_config;
+  draw_config.htemplate = new TH1F("TrackPT",
+                                   "",
+                                   nbinsx,
+                                   xmin,
+                                   xmax);
+
+  // draw_config.xlimits   = std::vector<float>();
+  // draw_config.xlimits.push_back(0);
+  // draw_config.xlimits.push_back(20);
+  draw_config.ylimits = std::vector < float > ();
+  draw_config.ylimits.push_back(0.0);
+  draw_config.ylimits.push_back(1e4);
+  draw_config.xtitle = "Track Momentum [GeV]";
+  draw_config.ytitle = "Frequency";
+  draw_config.logy   = kFALSE;
+  draw_config.logx   = kFALSE;
+  draw_config.cuts   = "";
+
+  // Kaon -> Kaon ID
+  auto true_kaon_pt = GeneratePlot(draw_config, data, "True Kaon PT", "pid_track_pt*TMath::CosH(pid_track_eta)", *cut_fiducial && cut_truekaon);
+  auto reco_kaon_pt = GeneratePlot(draw_config, data, "Reconstructed Kaon PT", "pid_track_pt*TMath::CosH(pid_track_eta)", *cut_fiducial && cut_truekaon && cut_recokaon);
+
+
+  TH1F *h_template = static_cast < TH1F * > (reco_kaon_pt->Clone("h_template"));
+  h_template->SetAxisRange(0.0, 1.12, "Y");
+  h_template->GetYaxis()->SetTitle("Efficiency");
+
+  auto pid_efficiency = new TEfficiency(*reco_kaon_pt,
+                                        *true_kaon_pt);
+  pid_efficiency->SetMarkerColor(kBlue);
+  pid_efficiency->SetFillColor(kBlue);
+  pid_efficiency->SetLineColor(kBlue);
+  pid_efficiency->SetMarkerStyle(kOpenSquare);
+
+  // Pion -> Kaon ID
+  auto true_pion_pt = GeneratePlot(draw_config, data, "True Pion PT", "pid_track_pt*TMath::CosH(pid_track_eta)", *cut_fiducial && cut_truepion);
+  auto reco_pion_pt = GeneratePlot(draw_config, data, "Reconstructed Pion PT", "pid_track_pt*TMath::CosH(pid_track_eta)", *cut_fiducial && cut_truepion && cut_recokaon);
+
+
+  auto misid_efficiency = new TEfficiency(*reco_pion_pt,
+                                          *true_pion_pt);
+  misid_efficiency->SetMarkerColor(kRed);
+  misid_efficiency->SetFillColor(kRed);
+  misid_efficiency->SetLineColor(kRed);
+  misid_efficiency->SetMarkerStyle(kFullCrossX);
+
+  // Draw!
+  TCanvas c1("c1",
+             "",
+             800,
+             600);
+
+  c1.cd();
+
+  // true_kaon_pt->Draw("HIST");
+  // reco_kaon_pt->Draw("E1 SAME");
+  h_template->Draw("AXIS");
+  pid_efficiency->Draw("E1 SAME");
+  misid_efficiency->Draw("E1 SAME");
+
+  TLatex etaRange((xmin + (xmax - xmin) * 0.67),
+                  1.05,
+                  Form("%0.1f < #eta < %0.1f", etaMin, etaMax));
+  etaRange.Draw();
+
+  // legend
+  auto *legend = smart_legend("lower left");
+  legend->AddEntry(pid_efficiency,   "K^{#pm} #rightarrow K^{#pm}",   "lp");
+  legend->AddEntry(misid_efficiency, "#pi^{#pm} #rightarrow K^{#pm}", "lp");
+  legend->Draw();
+
+  c1.SaveAs(Form("%s_KaonIDStudy.pdf", trackname.Data()));
+}

--- a/SimpleAnalysis/scripts/PlotFunctions.h
+++ b/SimpleAnalysis/scripts/PlotFunctions.h
@@ -43,6 +43,7 @@ struct plot_config {
   std::vector<float> ylimits;
   bool logy = kFALSE;
   bool logx = kFALSE;
+  TString cuts = "";
 
   int markercolor = kBlack;
   int markerstyle = kDot;
@@ -67,13 +68,13 @@ inline Int_t getHistUID()
 }
 
 
-inline float smart_legend_x(float x_trial, float x_width) 
+inline float smart_legend_x(float x_trial, float x_width)
 {
   float excess = 0.92 - (x_trial + x_width);
   float x_new = x_trial;
 
   if (excess < 0.0) {
-    std::cout << "smart_legend_x(): x width overshoots range - shifting by " << excess << std::endl; 
+    std::cout << "smart_legend_x(): x width overshoots range - shifting by " << excess << std::endl;
     x_new = x_trial + excess;
   }
 
@@ -81,13 +82,13 @@ inline float smart_legend_x(float x_trial, float x_width)
 
 }
 
-inline float smart_legend_y(float y_trial, float y_height) 
+inline float smart_legend_y(float y_trial, float y_height)
 {
   float excess = 0.92 - (y_trial + y_height);
   float y_new = y_trial;
 
   if (excess < 0.0) {
-    std::cout << "smart_legend_y(): y height overshoots range - shifting by " << excess << std::endl; 
+    std::cout << "smart_legend_y(): y height overshoots range - shifting by " << excess << std::endl;
     y_new = y_trial + excess;
   }
 
@@ -122,7 +123,7 @@ inline TLegend* smart_legend(std::string where = "upper right", float legend_wid
     legend_y = smart_legend_y(0.20, legend_height);
   } else {
     std::cout << "You specified a placement of " << where << " that is unknown..." << std::endl;
-    
+
   }
 
   legend = new TLegend(legend_x, legend_y, legend_x + legend_width, legend_y + legend_height);
@@ -143,7 +144,7 @@ inline void set_axis_range(TH1F* hist, float min, float max, std::string which =
     hist->GetYaxis()->SetLimits(min, max);
     hist->GetYaxis()->SetRangeUser(min, max);
   }
-  
+
 }
 
 template <class T> void configure_plot(T* object, plot_config options, std::string which = "" )
@@ -209,27 +210,27 @@ float LookupCrossSection(TString samplename)
 
 
 
-TH1F* GeneratePlot(plot_config draw_config, 
+TH1F* GeneratePlot(plot_config draw_config,
 		   TTree* data,
 		   TString name,
 		   TString x,
 		   TCut selection)
 {
   TH1F* plot = static_cast<TH1F*>(draw_config.htemplate->Clone(Form("%s_%d", name.Data(), getHistUID())));
-  
+
   data->Project(plot->GetName(), x.Data(), selection);
 
   plot->SetLineColor(draw_config.linecolor);
   plot->SetLineStyle(draw_config.linestyle);
-  
+
   plot->SetFillStyle(draw_config.fillstyle);
   plot->SetFillColor(draw_config.fillcolor);
-  
+
   plot->SetMarkerColor(draw_config.markercolor);
   plot->SetMarkerStyle(draw_config.markerstyle);
 
   plot->SetXTitle( draw_config.xtitle );
   plot->SetYTitle( draw_config.ytitle );
-  
+
   return plot;
 }

--- a/delphes_card_EIC.tcl
+++ b/delphes_card_EIC.tcl
@@ -67,6 +67,9 @@ set ExecutionPath {
   TrackCountingBTagging
 
   mRICHPID
+  barrelDircPID
+  CF4RICHPID
+  TofBarrelPID
 
   TreeWriter
 }
@@ -803,717 +806,780 @@ module TrackCountingBTagging TrackCountingBTagging {
 
 # mRICH
 
-module IdentificationMap mRICHPID {
+# module IdentificationMap mRICHPID {
+#   set InputArray HCal/eflowTracks
+#   set OutputArray tracks
+
+#   # {PID in} {PID out} {formula}
+#   # make sure "PID in" and "PID out" have the same charge (e.g {-13} {211} or {-321} {211})
+#   # {211} {-13} is equivalent to {-211} {13} (and needs to be written once only...)
+
+
+
+#  # From EIC Yellow Report PID studies, the mRICH coverage is -3.5<eta<-1 and 1<eta<2
+
+
+#   # --- pions ---
+
+#   add EfficiencyFormula {-11} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.99) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.98) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.96) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.92) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.87) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.82) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.77) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.73) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.69) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.65) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.62) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.60) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.58) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.57) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.56) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.55) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.54) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.53) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.53) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.50) } 
+
+#     add EfficiencyFormula {-11} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.08) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.13) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.27) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.31) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.35) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.50) } 
+
+#     add EfficiencyFormula {211} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.98) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.96) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.92) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.87) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.82) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.77) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.73) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.69) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.65) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.62) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.60) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.58) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.57) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.56) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.55) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.54) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.53) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.53) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.51) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.41) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.41) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.38) } 
+
+#     add EfficiencyFormula {211} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.08) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.13) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.27) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.31) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.35) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.49) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.48) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.47) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.46) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.45) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.44) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.43) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.42) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.41) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.41) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.40) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.39) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.38) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.38) } 
+
+#     add EfficiencyFormula {211} {321} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
+
+#     add EfficiencyFormula {321} {321} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (1.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.99) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.99) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.99) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.99) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.98) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.98) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.97) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.96) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.95) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.94) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.92) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.91) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.89) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.88) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.86) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.84) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.82) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.80) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.78) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.76) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.74) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.72) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.70) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.68) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.66) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.65) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.63) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.61) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.60) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.58) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.57) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.56) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.54) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.53) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.52) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.52) } 
+
+#     add EfficiencyFormula {321} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
+
+#     add EfficiencyFormula {321} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
+#                                      ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
+
+
+#  # efficiency for other charged particles (should be always {0} {0} {formula})
+
+#     add EfficiencyFormula {0} {0}     {      (fabs(eta) < 4.0) * (0.00)     }
+
+# }
+
+
+module EICPIDDetector barrelDircPID {
+  set InputArray HCal/eflowTracks
+  set OutputArray tracks
+    
+  set DetectorName barrelDirc 
+
+  # For QE, 0 means 27% and 1 means 22% for the barrelDIRC code
+  set QuantumEfficiency 0 
+  set TrackResolution 0.5
+  set TimeResolution 0.1
+
+
+  add Hypotheses {321} {211}
+}
+
+module EICPIDDetector mRICHPID {
   set InputArray HCal/eflowTracks
   set OutputArray tracks
 
-  # {PID in} {PID out} {formula}
-  # make sure "PID in" and "PID out" have the same charge (e.g {-13} {211} or {-321} {211})
-  # {211} {-13} is equivalent to {-211} {13} (and needs to be written once only...)
+  ##
+  ## mRICH Settings 
+  ##
+  set DetectorName mRICH
+  set PixelSize 3.0
+  set TrackResolution 0.00175
+  set TimeResolution 1.0
 
 
-
- # From EIC Yellow Report PID studies, the mRICH coverage is -3.5<eta<-1 and 1<eta<2
-
-
-  # --- pions ---
-
-  add EfficiencyFormula {-11} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.99) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.98) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.96) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.92) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.87) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.82) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.77) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.73) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.69) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.65) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.62) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.60) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.58) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.57) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.56) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.55) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.54) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.53) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.53) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.50) } 
-
-    add EfficiencyFormula {-11} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.08) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.13) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.27) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.31) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.35) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.50) } 
-
-    add EfficiencyFormula {211} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.98) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.96) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.92) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.87) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.82) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.77) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.73) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.69) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.65) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.62) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.60) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.58) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.57) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.56) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.55) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.54) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.53) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.53) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.51) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.41) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.41) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.38) } 
-
-    add EfficiencyFormula {211} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.08) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.13) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.27) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.31) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.35) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.50) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.49) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.48) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.47) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.46) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.45) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.44) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.43) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.42) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.41) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.41) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.40) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.39) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.38) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.38) } 
-
-    add EfficiencyFormula {211} {321} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
-
-    add EfficiencyFormula {321} {321} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (1.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.99) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.99) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.99) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.99) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.98) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.98) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.97) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.96) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.95) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.94) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.92) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.91) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.89) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.88) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.86) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.84) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.82) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.80) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.78) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.76) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.74) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.72) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.70) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.68) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.66) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.65) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.63) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.61) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.60) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.58) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.57) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.56) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.54) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.53) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.52) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.52) } 
-
-    add EfficiencyFormula {321} {-11} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
-
-    add EfficiencyFormula {321} {211} { (eta<-3.5 || (-1 < eta && eta < 1) || eta>2.0)*( 0.00 ) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 0.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (0.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 1.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (1.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 2.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (2.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 3.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (3.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 4.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (4.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 5.90) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (5.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.00) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.10) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.20) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.30) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.40) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.50) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.60) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.70) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.80) * (0.00) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 6.90) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (6.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.00) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.10) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.20) * (0.01) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.30) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.40) * (0.02) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.50) * (0.03) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.60) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.70) * (0.04) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.80) * (0.05) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 7.90) * (0.06) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (7.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.00) * (0.07) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.10) * (0.08) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.20) * (0.09) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.30) * (0.10) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.40) * (0.11) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.50) * (0.12) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.60) * (0.13) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.70) * (0.14) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.80) * (0.15) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 8.90) * (0.16) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (8.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.00) * (0.17) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.00 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.10) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.10 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.20) * (0.18) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.20 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.30) * (0.19) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.30 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.40) * (0.20) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.40 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.50) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.50 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.60) * (0.21) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.60 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.70) * (0.22) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.70 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.80) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.80 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 9.90) * (0.23) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (9.90 <= (pt * cosh(eta)) && (pt * cosh(eta)) < 10.00) * (0.24) + 
-                                     ((-3.5 <= eta && eta <= -1.0) || (1.0 <= eta && eta <= 2.0)) * (10.00 <= (pt * cosh(eta))) * (0.24) } 
-
-
- # efficiency for other charged particles (should be always {0} {0} {formula})
-
-    add EfficiencyFormula {0} {0}     {      (fabs(eta) < 4.0) * (0.00)     }
-
+  add Hypotheses {321} {211}
 }
 
+module EICPIDDetector CF4RICHPID {
+  set InputArray HCal/eflowTracks
+  set OutputArray tracks
 
+  ##
+  ## CF4RICH Settings 
+  ##
+  set EtaLow 1.0
+  set EtaHigh 4.0
+  set DetectorName CF4rich
+  set PixelSize 3.0
+  set TrackResolution 0.01
+  set DetectorLength 1500
+
+
+  add Hypotheses {321} {211}
+}
+
+module EICPIDDetector TofBarrelPID {
+  set InputArray HCal/eflowTracks
+  set OutputArray tracks
+
+  ##
+  ## TOF Barrel Detector Settings 
+  ##
+  set DetectorName tofBarrel
+  set EtaLow -2.0
+  set EtaHigh 2.0
+
+
+  add Hypotheses {321} {211}
+}
 
 
 ##################
@@ -1536,6 +1602,9 @@ module TreeWriter TreeWriter {
   add Branch HCal/eflowNeutralHadrons EFlowNeutralHadron Tower
 
   add Branch mRICHPID/tracks mRICHTrack Track
+  add Branch CF4RICHPID/tracks CF4RICHTrack Track
+  add Branch barrelDircPID/tracks barrelDircTrack Track
+  add Branch TofBarrelPID/tracks tofBarrelTrack Track
 
   add Branch GenJetFinder/jets GenJet Jet
   add Branch GenMissingET/momentum GenMissingET MissingET

--- a/delphes_card_EIC.tcl
+++ b/delphes_card_EIC.tcl
@@ -70,6 +70,8 @@ set ExecutionPath {
   barrelDircPID
   CF4RICHPID
   TofBarrelPID
+  dualRICHagPID
+  dualRICHcfPID
 
   TreeWriter
 }
@@ -1527,6 +1529,8 @@ module EICPIDDetector barrelDircPID {
   set QuantumEfficiency 0 
   set TrackResolution 0.5
   set TimeResolution 0.1
+  set EtaLow -1.0
+  set EtaHigh 1.0
 
 
   add Hypotheses {321} {211}
@@ -1543,7 +1547,8 @@ module EICPIDDetector mRICHPID {
   set PixelSize 3.0
   set TrackResolution 0.00175
   set TimeResolution 1.0
-
+  set EtaLow -4.0
+  set EtaHigh -1.0
 
   add Hypotheses {321} {211}
 }
@@ -1581,6 +1586,32 @@ module EICPIDDetector TofBarrelPID {
   add Hypotheses {321} {211}
 }
 
+module EICPIDDetector dualRICHagPID {
+  set InputArray HCal/eflowTracks
+  set OutputArray tracks
+
+  ##
+  ## TOF Barrel Detector Settings 
+  ##
+  set DetectorName dualRICH_aerogel
+
+
+  add Hypotheses {321} {211}
+}
+
+module EICPIDDetector dualRICHcfPID {
+  set InputArray HCal/eflowTracks
+  set OutputArray tracks
+
+  ##
+  ## TOF Barrel Detector Settings 
+  ##
+  set DetectorName dualRICH_C2F6
+
+
+  add Hypotheses {321} {211}
+}
+
 
 ##################
 # ROOT tree writer
@@ -1605,6 +1636,9 @@ module TreeWriter TreeWriter {
   add Branch CF4RICHPID/tracks CF4RICHTrack Track
   add Branch barrelDircPID/tracks barrelDircTrack Track
   add Branch TofBarrelPID/tracks tofBarrelTrack Track
+  add Branch dualRICHagPID/tracks dRICHagTrack Track
+  add Branch dualRICHcfPID/tracks dRICHcfTrack Track
+
 
   add Branch GenJetFinder/jets GenJet Jet
   add Branch GenMissingET/momentum GenMissingET MissingET


### PR DESCRIPTION
This project for now will depend on private forks of DELPHES and the EIC PID code, because modifications to those projects were needed to allow the PID code to be included in DELPHES (Makefile and new external dependency on PID code) and PID (code was not compilable out-of-the-box, but is now).

Three main systems are now added to the default TCL configuration script for the baseline detector model: the mRICH (electron endcap), the barrel DIRC (barrel region), and the dual RICH (hadron endcap).

SimpleAnalysis has been updated to load kaon candidates from these systems by default and use them in making output TTree content.